### PR TITLE
Add Ollama embedding support to enable local embedding models

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,28 +97,6 @@ uv sync
 
 </details>
 
-
-### 🆕 Using Ollama for Embeddings (Privacy-Focused)
-
-LEANN now supports Ollama for generating embeddings locally, perfect for privacy-sensitive applications:
-
-```bash
-# First, pull an embedding model from Ollama
-ollama pull nomic-embed-text  # or mxbai-embed-large, bge-m3, etc.
-
-# Build an index using Ollama embeddings
-leann build my-project --docs ./documents --embedding-model nomic-embed-text --embedding-mode ollama
-
-# Use with example apps
-python -m apps.document_rag --embedding-model nomic-embed-text --embedding-mode ollama --query "Your question"
-```
-
-**Available Ollama Embedding Models:**
-- `nomic-embed-text`: High-performing 768-dim embeddings
-- `mxbai-embed-large`: Large 1024-dim embeddings
-- `bge-m3`: Multilingual embeddings
-- See [Ollama library](https://ollama.com/library) for more embedding models
-
 ## Quick Start
 
 Our declarative API makes RAG as easy as writing a config file.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,27 @@ uv sync
 </details>
 
 
+### 🆕 Using Ollama for Embeddings (Privacy-Focused)
+
+LEANN now supports Ollama for generating embeddings locally, perfect for privacy-sensitive applications:
+
+```bash
+# First, pull an embedding model from Ollama
+ollama pull nomic-embed-text  # or mxbai-embed-large, bge-m3, etc.
+
+# Build an index using Ollama embeddings
+leann build my-project --docs ./documents --embedding-model nomic-embed-text --embedding-mode ollama
+
+# Use with example apps
+python -m apps.document_rag --embedding-model nomic-embed-text --embedding-mode ollama --query "Your question"
+```
+
+**Available Ollama Embedding Models:**
+- `nomic-embed-text`: High-performing 768-dim embeddings
+- `mxbai-embed-large`: Large 1024-dim embeddings
+- `bge-m3`: Multilingual embeddings
+- See [Ollama library](https://ollama.com/library) for more embedding models
+
 ## Quick Start
 
 Our declarative API makes RAG as easy as writing a config file.
@@ -189,8 +210,8 @@ All RAG examples share these common parameters. **Interactive mode** is availabl
 --force-rebuild         # Force rebuild index even if it exists
 
 # Embedding Parameters
---embedding-model MODEL  # e.g., facebook/contriever, text-embedding-3-small or mlx-community/multilingual-e5-base-mlx
---embedding-mode MODE    # sentence-transformers, openai, or mlx
+--embedding-model MODEL  # e.g., facebook/contriever, text-embedding-3-small, nomic-embed-text, or mlx-community/multilingual-e5-base-mlx
+--embedding-mode MODE    # sentence-transformers, openai, mlx, or ollama
 
 # LLM Parameters (Text generation models)
 --llm TYPE              # LLM backend: openai, ollama, or hf (default: openai)

--- a/apps/base_rag_example.py
+++ b/apps/base_rag_example.py
@@ -75,7 +75,7 @@ class BaseRAGExample(ABC):
             "--embedding-mode",
             type=str,
             default="sentence-transformers",
-            choices=["sentence-transformers", "openai", "mlx"],
+            choices=["sentence-transformers", "openai", "mlx", "ollama"],
             help="Embedding backend mode (default: sentence-transformers)",
         )
 
@@ -85,7 +85,7 @@ class BaseRAGExample(ABC):
             "--llm",
             type=str,
             default="openai",
-            choices=["openai", "ollama", "hf"],
+            choices=["openai", "ollama", "hf", "simulated"],
             help="LLM backend to use (default: openai)",
         )
         llm_group.add_argument(

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -49,12 +49,23 @@ Based on our experience developing LEANN, embedding models fall into three categ
 - **Cons**: Slower inference, longer index build times
 - **Use when**: Quality is paramount and you have sufficient compute resources. **Highly recommended** for production use
 
-### Quick Start: OpenAI Embeddings (Fastest Setup)
+### Quick Start: Cloud and Local Embedding Options
 
+**OpenAI Embeddings (Fastest Setup)**
 For immediate testing without local model downloads:
 ```bash
 # Set OpenAI embeddings (requires OPENAI_API_KEY)
 --embedding-mode openai --embedding-model text-embedding-3-small
+```
+
+**Ollama Embeddings (Privacy-Focused)**
+For local embeddings with complete privacy:
+```bash
+# First, pull an embedding model
+ollama pull nomic-embed-text
+
+# Use Ollama embeddings
+--embedding-mode ollama --embedding-model nomic-embed-text
 ```
 
 <details>

--- a/packages/leann-backend-diskann/leann_backend_diskann/diskann_embedding_server.py
+++ b/packages/leann-backend-diskann/leann_backend_diskann/diskann_embedding_server.py
@@ -261,7 +261,7 @@ if __name__ == "__main__":
         "--embedding-mode",
         type=str,
         default="sentence-transformers",
-        choices=["sentence-transformers", "openai", "mlx"],
+        choices=["sentence-transformers", "openai", "mlx", "ollama"],
         help="Embedding backend mode",
     )
     parser.add_argument(

--- a/packages/leann-backend-hnsw/leann_backend_hnsw/hnsw_embedding_server.py
+++ b/packages/leann-backend-hnsw/leann_backend_hnsw/hnsw_embedding_server.py
@@ -295,7 +295,7 @@ if __name__ == "__main__":
         "--embedding-mode",
         type=str,
         default="sentence-transformers",
-        choices=["sentence-transformers", "openai", "mlx"],
+        choices=["sentence-transformers", "openai", "mlx", "ollama"],
         help="Embedding backend mode",
     )
 

--- a/packages/leann-core/src/leann/cli.py
+++ b/packages/leann-core/src/leann/cli.py
@@ -94,6 +94,13 @@ Examples:
             "--backend", type=str, default="hnsw", choices=["hnsw", "diskann"]
         )
         build_parser.add_argument("--embedding-model", type=str, default="facebook/contriever")
+        build_parser.add_argument(
+            "--embedding-mode",
+            type=str,
+            default="sentence-transformers",
+            choices=["sentence-transformers", "openai", "mlx", "ollama"],
+            help="Embedding backend mode (default: sentence-transformers)",
+        )
         build_parser.add_argument("--force", "-f", action="store_true", help="Force rebuild")
         build_parser.add_argument("--graph-degree", type=int, default=32)
         build_parser.add_argument("--complexity", type=int, default=64)
@@ -469,6 +476,7 @@ Examples:
         builder = LeannBuilder(
             backend_name=args.backend,
             embedding_model=args.embedding_model,
+            embedding_mode=args.embedding_mode,
             graph_degree=args.graph_degree,
             complexity=args.complexity,
             is_compact=args.compact,


### PR DESCRIPTION
This PR adds support for Ollama as an embedding provider, allowing users to use local embedding models like nomic-embed-text for privacy-focused applications.