### PR TITLE
🔗 Auto-register apps: Universal index discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,9 @@ leann ask my-docs --interactive
 
 # List all your indexes
 leann list
+
+# Remove an index
+leann remove my-docs
 ```
 
 **Key CLI features:**
@@ -496,7 +499,7 @@ leann list
 <details>
 <summary><strong>📋 Click to expand: Complete CLI Reference</strong></summary>
 
-You can use `leann --help`, or `leann build --help`, `leann search --help`, `leann ask --help` to get the complete CLI reference.
+You can use `leann --help`, or `leann build --help`, `leann search --help`, `leann ask --help`, `leann list --help`, `leann remove --help` to get the complete CLI reference.
 
 **Build Command:**
 ```bash
@@ -532,6 +535,31 @@ Options:
   --model MODEL               Model name (default: qwen3:8b)
   --interactive              Interactive chat mode
   --top-k N                  Retrieval count (default: 20)
+```
+
+**List Command:**
+```bash
+leann list
+
+# Lists all indexes across all projects with status indicators:
+# ✅ - Index is complete and ready to use
+# ❌ - Index is incomplete or corrupted
+# 📁 - CLI-created index (in .leann/indexes/)
+# 📄 - App-created index (*.leann.meta.json files)
+```
+
+**Remove Command:**
+```bash
+leann remove INDEX_NAME [OPTIONS]
+
+Options:
+  --force, -f    Force removal without confirmation
+
+# Smart removal: automatically finds and safely removes indexes
+# - Shows all matching indexes across projects
+# - Requires confirmation for cross-project removal
+# - Interactive selection when multiple matches found
+# - Supports both CLI and app-created indexes
 ```
 
 </details>

--- a/apps/base_rag_example.py
+++ b/apps/base_rag_example.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import dotenv
 from leann.api import LeannBuilder, LeannChat
+from leann.registry import register_project_directory
 from llama_index.core.node_parser import SentenceSplitter
 
 dotenv.load_dotenv()
@@ -213,6 +214,11 @@ class BaseRAGExample(ABC):
         print("Building index structure...")
         builder.build_index(index_path)
         print(f"Index saved to: {index_path}")
+
+        # Register project directory so leann list can discover this index
+        # The index is saved as args.index_dir/index_name.leann
+        # We want to register the current working directory where the app is run
+        register_project_directory(Path.cwd())
 
         return index_path
 

--- a/packages/leann-core/src/leann/registry.py
+++ b/packages/leann-core/src/leann/registry.py
@@ -2,10 +2,16 @@
 
 import importlib
 import importlib.metadata
+import json
+import logging
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from leann.interface import LeannBackendFactoryInterface
+
+# Set up logger for this module
+logger = logging.getLogger(__name__)
 
 BACKEND_REGISTRY: dict[str, "LeannBackendFactoryInterface"] = {}
 
@@ -14,7 +20,7 @@ def register_backend(name: str):
     """A decorator to register a new backend class."""
 
     def decorator(cls):
-        print(f"INFO: Registering backend '{name}'")
+        logger.debug(f"Registering backend '{name}'")
         BACKEND_REGISTRY[name] = cls
         return cls
 
@@ -39,3 +45,54 @@ def autodiscover_backends():
             # print(f"WARN: Could not import backend module '{backend_module_name}': {e}")
             pass
     # print("INFO: Backend auto-discovery finished.")
+
+
+def register_project_directory(project_dir: str | Path | None = None):
+    """
+    Register a project directory in the global LEANN registry.
+
+    This allows `leann list` to discover indexes created by apps or other tools.
+
+    Args:
+        project_dir: Directory to register. If None, uses current working directory.
+    """
+    if project_dir is None:
+        project_dir = Path.cwd()
+    else:
+        project_dir = Path(project_dir)
+
+    # Only register directories that have some kind of LEANN content
+    # Either .leann/indexes/ (CLI format) or *.leann.meta.json files (apps format)
+    has_cli_indexes = (project_dir / ".leann" / "indexes").exists()
+    has_app_indexes = any(project_dir.rglob("*.leann.meta.json"))
+
+    if not (has_cli_indexes or has_app_indexes):
+        # Don't register if there are no LEANN indexes
+        return
+
+    global_registry = Path.home() / ".leann" / "projects.json"
+    global_registry.parent.mkdir(exist_ok=True)
+
+    project_str = str(project_dir.resolve())
+
+    # Load existing registry
+    projects = []
+    if global_registry.exists():
+        try:
+            with open(global_registry) as f:
+                projects = json.load(f)
+        except Exception:
+            logger.debug("Could not load existing project registry")
+            projects = []
+
+    # Add project if not already present
+    if project_str not in projects:
+        projects.append(project_str)
+
+        # Save updated registry
+        try:
+            with open(global_registry, "w") as f:
+                json.dump(projects, f, indent=2)
+            logger.debug(f"Registered project directory: {project_str}")
+        except Exception as e:
+            logger.warning(f"Could not save project registry: {e}")


### PR DESCRIPTION
## Summary

This PR enables **universal index discovery** by making apps automatically register their indexes and extending `leann list` to discover all index formats.

### 🔗 Automatic App Registration
- **Smart Registration**: Apps automatically register projects after creating indexes
- **Public API**: New `register_project_directory()` function in `leann.registry`
- **Seamless Integration**: All apps now auto-register via `BaseRAGExample`

### 📁📄 Multi-Format Index Discovery  
- **CLI Format**: Discovers `.leann/indexes/` structure with 📁 icon
- **Apps Format**: Discovers `*.leann.meta.json` files with 📄 icon
- **Unified Display**: Both formats shown together with clear visual distinction
- **Accurate Sizing**: Proper size calculation for multi-file app indexes

### 🎯 User Experience

**Before:**
```bash
leann list
# Only shows CLI-created indexes
# Apps indexes are "invisible"
```

**After:**
```bash
leann list
🏠 Current Project
   1. 📁 my-docs ✅        # CLI-created index
   2. 📄 test_doc_files ✅  # App-created index
```

### 🛠️ Technical Implementation
- **Registry Logic**: Only register directories with actual LEANN content
- **Robust Discovery**: Handles both `.leann/indexes/` and `*.leann.meta.json` patterns
- **Error Handling**: Graceful handling of file permissions and missing files
- **Performance**: Efficient scanning with proper path resolution

## Test plan

- [x] Apps automatically register after creating indexes
- [x] `leann list` discovers both CLI and app formats
- [x] Visual distinction with appropriate icons (📁 vs 📄)
- [x] Accurate size calculation for all index types
- [x] Registry validation (only actual index directories)
- [x] Cross-project discovery works correctly
- [x] No duplicate registrations

## Impact

🎉 **Complete index visibility** - Users can now see ALL their LEANN indexes regardless of how they were created (CLI, document_rag, email_rag, browser_rag, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)