### PR TITLE
docs(mcp): add llms.txt for MCP discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ demo/experiment_results/**/*.json
 *.sh
 *.txt
 !CMakeLists.txt
+!llms.txt
 latency_breakdown*.json
 experiment_results/eval_results/diskann/*.json
 aws/

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,28 @@
+# llms.txt — LEANN MCP and Agent Integration
+product: LEANN
+homepage: https://github.com/yichuan-w/LEANN
+contact: https://github.com/yichuan-w/LEANN/issues
+
+# Installation
+install: uv tool install leann-core --with leann
+
+# MCP Server Entry Point
+mcp.server: leann_mcp
+mcp.protocol_version: 2024-11-05
+
+# Tools
+mcp.tools: leann_list, leann_search
+
+mcp.tool.leann_list.description: List available LEANN indexes
+mcp.tool.leann_list.input: {}
+
+mcp.tool.leann_search.description: Semantic search across a named LEANN index
+mcp.tool.leann_search.input.index_name: string, required
+mcp.tool.leann_search.input.query: string, required
+mcp.tool.leann_search.input.top_k: integer, optional, default=5, min=1, max=20
+mcp.tool.leann_search.input.complexity: integer, optional, default=32, min=16, max=128
+
+# Notes
+note: Build indexes with `leann build <name> --docs <files...>` before searching.
+example.add: claude mcp add --scope user leann-server -- leann_mcp
+example.verify: claude mcp list | cat

--- a/packages/leann-mcp/README.md
+++ b/packages/leann-mcp/README.md
@@ -2,6 +2,8 @@
 
 Transform your development workflow with intelligent code assistance using LEANN's semantic search directly in Claude Code.
 
+For agent-facing discovery details, see `llms.txt` in the repository root.
+
 ## Prerequisites
 
 Install LEANN globally for MCP integration (with default backend):


### PR DESCRIPTION
docs(mcp): add llms.txt for MCP discovery

- added `llms.txt` at repo root to inform MCP server (`leann_mcp`), protocol version, and tools (`leann_list`, `leann_search`).
- update `packages/leann-mcp/README.md` to reference `llms.txt` for agent discovery.

refs #76

BREAKING CHANGES: none

why
- helps coding agents (Claude Code, Cursor, etc.) discover and use LEANN via MCP quickly.
- keeps MCP discovery self-describing without duplicating docs.

scope
- implements the `llms.txt` portion only. current MCP server supports Tools (`tools/list`, `tools/call`); 
- will add more tools to the mcp for next PR

mobile note (deferred)
- app sandboxing restricts filesystem traversal and local server usage needed for indexing; requires specific entitlements.
- iOS codesigning/notarization adds distribution complexity; iOS further limits background tasks, model size, memory.
- focusing on MCP + desktop is the short-term goal; mobile can be tracked separately.

