### PR TITLE
Fix 'leann ask' positional query handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,9 @@ leann search my-docs "machine learning concepts"
 # Interactive chat with your documents
 leann ask my-docs --interactive
 
+# Ask a single question (non-interactive)
+leann ask my-docs "Where are prompts configured?"
+
 # List all your indexes
 leann list
 

--- a/tests/test_cli_ask.py
+++ b/tests/test_cli_ask.py
@@ -1,0 +1,14 @@
+from leann.cli import LeannCLI
+
+
+def test_cli_ask_accepts_positional_query(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    cli = LeannCLI()
+    parser = cli.create_parser()
+
+    args = parser.parse_args(["ask", "my-docs", "Where are prompts configured?"])
+
+    assert args.command == "ask"
+    assert args.index_name == "my-docs"
+    assert args.query == "Where are prompts configured?"


### PR DESCRIPTION
Fixes #110.

## Summary
- allow the ask parser to accept an optional positional question so `leann ask my-docs "..."` works
- reuse the provided question in interactive/non-interactive flows and add a parser regression test

## Testing
- `uv run python -m pytest tests/test_cli_ask.py`