### PR TITLE
Changing the option name "--backend" for "--backend-name"

### DIFF
--- a/packages/leann-core/src/leann/cli.py
+++ b/packages/leann-core/src/leann/cli.py
@@ -106,7 +106,7 @@ Examples:
             help="Documents directories and/or files (default: current directory)",
         )
         build_parser.add_argument(
-            "--backend",
+            "--backend-name",
             type=str,
             default="hnsw",
             choices=["hnsw", "diskann"],


### PR DESCRIPTION
## What does this PR do?

Changed the option name "--backend" for "--backend-name" as written in the documentation