### PR TITLE
[bug] fix when no package name found

### DIFF
--- a/packages/leann-core/src/leann/registry.py
+++ b/packages/leann-core/src/leann/registry.py
@@ -34,7 +34,7 @@ def autodiscover_backends():
     for dist in importlib.metadata.distributions():
         dist_name = dist.metadata["name"]
         if dist_name is None:
-            continue;
+            continue
         if dist_name.startswith("leann-backend-"):
             backend_module_name = dist_name.replace("-", "_")
             discovered_backends.append(backend_module_name)


### PR DESCRIPTION
This bug will not likely to happen with uv package manager, since all package installed correctly.
However, when used without uv, packages in Python might be corrupted and package name might be iNone, resulting in a code crash in `dist_name.startswith("leann-backend-")` since `dist_name is None`

Reasons why Python package might be without name
```
* Editable installs (pip install -e) sometimes produce incomplete metadata in development mode.
* Local builds / hand-copied packages may have .dist-info folders missing the Name: field.
* Namespace packages or broken installs (e.g., partial wheel extractions) show up in importlib.metadata.distributions() but   don’t have proper metadata.
* PEP 660 editable installs (newer pip behavior) can produce temporary or shim distributions that lack a Name entry.
