### PR TITLE
feat: add GH_PAT token and fetch-depth to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 1
-          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT != '' && secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           ref: ${{ inputs.ref }}
 
       - name: Install uv and Python
@@ -95,7 +95,7 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 1
-          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT != '' && secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           ref: ${{ inputs.ref }}
 
       - name: Install uv and Python

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT != '' && secrets.GH_PAT || secrets.GITHUB_TOKEN }}
       - uses: lycheeverse/lychee-action@v2
         with:
           args: --no-progress --insecure --user-agent 'curl/7.68.0' --exclude '.*api\.star-history\.com.*' --accept 200,201,202,203,204,205,206,207,208,226,300,301,302,303,304,305,306,307,308,503 README.md docs/ apps/ examples/ benchmarks/

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT != '' && secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Validate version
         run: |
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT != '' && secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           ref: 'main'
 
       - name: Download all artifacts


### PR DESCRIPTION
## Changes

This PR adds the following configurations to all checkout actions in GitHub Actions workflows:

- `fetch-depth: 1`: Only fetch the latest commit to speed up checkout
- `token: ${{ secrets.GH_PAT }}`: Use Personal Access Token for authentication, enabling access to private submodules

## Modified Files

- `.github/workflows/build-reusable.yml` (2 locations)
- `.github/workflows/link-check.yml` (1 location)  
- `.github/workflows/release-manual.yml` (2 locations)

## Important Notes

⚠️ Make sure to configure the `GH_PAT` secret in GitHub repository Settings → Secrets and variables → Actions before merging.

## Related Notes

This step is critical to ensure workflows can properly access private submodules and improve checkout performance.