### PR TITLE
feat: implement global index registry for O(1) index discovery

### DIFF
--- a/packages/leann-core/src/leann/cli.py
+++ b/packages/leann-core/src/leann/cli.py
@@ -10,7 +10,12 @@ from tqdm import tqdm
 
 from .api import LeannBuilder, LeannChat, LeannSearcher
 from .interactive_utils import create_cli_session
-from .registry import register_project_directory
+from .registry import (
+    list_registered_indexes,
+    register_index,
+    register_project_directory,
+    unregister_index,
+)
 from .settings import (
     resolve_anthropic_base_url,
     resolve_ollama_host,
@@ -502,10 +507,137 @@ Examples:
     def list_indexes(self, max_depth: int = 3):
         """List all LEANN indexes across registered projects.
 
+        Uses the global index registry for O(1) lookup when available.
+        Falls back to directory scanning for legacy indexes not yet registered.
+
         Args:
             max_depth: Maximum directory depth to scan for app-format indexes.
                        Default is 3. Increase if indexes are in deeply nested directories.
         """
+        current_path = Path.cwd()
+
+        # Try to use global index registry first (O(1) lookup)
+        registered_indexes = list_registered_indexes(validate=True)
+
+        print("📚 LEANN Indexes")
+        print("=" * 50)
+
+        if registered_indexes:
+            # Use the fast path - global registry
+            self._list_indexes_from_registry(registered_indexes, current_path)
+        else:
+            # Fall back to directory scanning for legacy support
+            self._list_indexes_by_scanning(current_path, max_depth)
+
+    def _list_indexes_from_registry(self, registered_indexes: list, current_path: Path):
+        """List indexes using the global registry (O(1) lookup)."""
+        # Group indexes by project
+        current_indexes = []
+        other_indexes_by_project: dict[str, list] = {}
+
+        for idx in registered_indexes:
+            idx_path = Path(idx["path"])
+            # Determine which project this index belongs to
+            # CLI indexes: /path/to/project/.leann/indexes/name/documents.leann
+            # App indexes: /path/to/project/somewhere/file.leann
+            try:
+                if ".leann/indexes" in idx["path"]:
+                    # CLI format - project is 3 levels up from .leann
+                    project_path = idx_path.parent.parent.parent.parent
+                else:
+                    # App format - use parent directory
+                    project_path = idx_path.parent
+            except Exception:
+                project_path = idx_path.parent
+
+            # Calculate size
+            size_mb = 0
+            try:
+                meta_path = Path(idx["path"] + ".meta.json")
+                if meta_path.exists():
+                    index_dir = meta_path.parent
+                    for f in index_dir.glob(f"{meta_path.stem.replace('.meta', '')}*"):
+                        if f.is_file():
+                            size_mb += f.stat().st_size / (1024 * 1024)
+            except (OSError, PermissionError):
+                pass
+
+            index_info = {
+                "name": idx["name"],
+                "type": idx["index_type"],
+                "status": "✅",
+                "size_mb": size_mb,
+                "path": idx["path"],
+                "project_path": project_path,
+            }
+
+            # Check if this is in current project
+            try:
+                if project_path.resolve() == current_path.resolve():
+                    current_indexes.append(index_info)
+                else:
+                    project_key = str(project_path)
+                    if project_key not in other_indexes_by_project:
+                        other_indexes_by_project[project_key] = []
+                    other_indexes_by_project[project_key].append(index_info)
+            except Exception:
+                # If comparison fails, treat as other project
+                project_key = str(project_path)
+                if project_key not in other_indexes_by_project:
+                    other_indexes_by_project[project_key] = []
+                other_indexes_by_project[project_key].append(index_info)
+
+        total_indexes = len(registered_indexes)
+        current_indexes_count = len(current_indexes)
+
+        # Show current project first
+        print("\n🏠 Current Project")
+        print(f"   {current_path}")
+        print("   " + "─" * 45)
+
+        if current_indexes:
+            for i, idx in enumerate(current_indexes, 1):
+                type_icon = "📁" if idx["type"] == "cli" else "📄"
+                print(f"   {i}. {type_icon} {idx['name']} {idx['status']}")
+                if idx["size_mb"] > 0:
+                    print(f"      📦 Size: {idx['size_mb']:.1f} MB")
+        else:
+            print("   📭 No indexes in current project")
+
+        # Show other projects
+        if other_indexes_by_project:
+            print("\n\n🗂️  Other Projects")
+            print("   " + "─" * 45)
+
+            for project_key, indexes in other_indexes_by_project.items():
+                project_path = Path(project_key)
+                print(f"\n   📂 {project_path.name}")
+                print(f"      {project_path}")
+
+                for idx in indexes:
+                    type_icon = "📁" if idx["type"] == "cli" else "📄"
+                    print(f"      • {type_icon} {idx['name']} {idx['status']}")
+                    if idx["size_mb"] > 0:
+                        print(f"        📦 {idx['size_mb']:.1f} MB")
+
+        # Summary
+        print("\n" + "=" * 50)
+        projects_count = 1 if current_indexes else 0
+        projects_count += len(other_indexes_by_project)
+        print(f"📊 Total: {total_indexes} indexes across {projects_count} projects")
+        print("⚡ Using global registry (O(1) lookup)")
+
+        if current_indexes_count > 0:
+            print("\n💫 Quick start (current project):")
+            example_name = current_indexes[0]["name"]
+            print(f'   leann search {example_name} "your query"')
+            print(f"   leann ask {example_name} --interactive")
+        else:
+            print("\n💡 Create your first index:")
+            print("   leann build my-docs --docs ./documents")
+
+    def _list_indexes_by_scanning(self, current_path: Path, max_depth: int):
+        """List indexes by scanning directories (legacy fallback)."""
         # Get all project directories with .leann
         global_registry = Path.home() / ".leann" / "projects.json"
         all_projects = []
@@ -527,7 +659,6 @@ Examples:
                 valid_projects.append(project_path)
 
         # Add current project if it has .leann but not in registry
-        current_path = Path.cwd()
         if (current_path / ".leann" / "indexes").exists() and current_path not in valid_projects:
             valid_projects.append(current_path)
 
@@ -537,9 +668,6 @@ Examples:
         for project_path in valid_projects:
             if project_path != current_path:
                 other_projects.append(project_path)
-
-        print("📚 LEANN Indexes")
-        print("=" * 50)
 
         total_indexes = 0
         current_indexes_count = 0
@@ -599,6 +727,7 @@ Examples:
                 if len(discovered) > 0:
                     projects_count += 1
             print(f"📊 Total: {total_indexes} indexes across {projects_count} projects")
+            print("🔍 Using directory scan (run 'leann build' to enable fast registry)")
 
             if current_indexes_count > 0:
                 print("\n💫 Quick start (current project):")
@@ -974,11 +1103,21 @@ Examples:
     ):
         """Delete a CLI index directory or APP index files safely."""
         try:
+            # Determine index path for unregistering from global registry
+            index_path_for_registry = None
+
             if is_app:
                 removed = 0
                 errors = 0
                 # Delete only files that belong to this app index (based on file base)
                 pattern_base = app_file_base or ""
+
+                # Find the .leann file path for unregistering
+                for f in index_dir.glob(f"{pattern_base}.leann"):
+                    if f.is_file() and not f.name.endswith(".meta.json"):
+                        index_path_for_registry = str(f)
+                        break
+
                 for f in index_dir.glob(f"{pattern_base}.leann*"):
                     try:
                         f.unlink()
@@ -994,6 +1133,10 @@ Examples:
                         errors += 1
 
                 if removed > 0 and errors == 0:
+                    # Unregister from global registry
+                    if index_path_for_registry:
+                        unregister_index(index_path_for_registry)
+
                     if project_path:
                         print(
                             f"✅ App index '{index_display_name}' removed from {project_path.name}"
@@ -1014,7 +1157,13 @@ Examples:
             else:
                 import shutil
 
+                # For CLI indexes, the path is index_dir / "documents.leann"
+                index_path_for_registry = str(index_dir / "documents.leann")
+
                 shutil.rmtree(index_dir)
+
+                # Unregister from global registry
+                unregister_index(index_path_for_registry)
 
                 if project_path:
                     print(f"✅ Index '{index_display_name}' removed from {project_path.name}")
@@ -1521,7 +1670,10 @@ Examples:
         builder.build_index(index_path)
         print(f"Index built at {index_path}")
 
-        # Register this project directory in global registry
+        # Register this index in global registry for O(1) discovery
+        register_index(name=index_name, path=index_path, index_type="cli")
+
+        # Register this project directory in global registry (legacy support)
         self.register_project_dir()
 
     async def search_documents(self, args):

--- a/tests/test_cli_list_performance.py
+++ b/tests/test_cli_list_performance.py
@@ -1,0 +1,212 @@
+"""Tests for leann list command performance improvements.
+
+This module tests the limited-depth search functionality that prevents
+leann list from scanning all files in large directories like $HOME.
+See: https://github.com/yichuan-w/LEANN/issues/122
+"""
+
+from pathlib import Path
+
+
+class TestLimitedDepthSearch:
+    """Test the _find_meta_files_limited method for performance."""
+
+    def test_find_meta_files_respects_max_depth(self, tmp_path: Path):
+        """Meta files beyond max_depth should not be found."""
+        from leann.cli import LeannCLI
+
+        cli = LeannCLI()
+
+        # Create a deep directory structure
+        # depth 0: tmp_path
+        # depth 1: level1
+        # depth 2: level2
+        # depth 3: level3
+        # depth 4: level4 (beyond default max_depth=3)
+        level1 = tmp_path / "level1"
+        level2 = level1 / "level2"
+        level3 = level2 / "level3"
+        level4 = level3 / "level4"
+
+        level4.mkdir(parents=True)
+
+        # Create meta files at different depths
+        (tmp_path / "root.leann.meta.json").touch()
+        (level1 / "l1.leann.meta.json").touch()
+        (level2 / "l2.leann.meta.json").touch()
+        (level3 / "l3.leann.meta.json").touch()
+        (level4 / "l4.leann.meta.json").touch()
+
+        # Find with max_depth=3 (should find root, l1, l2, l3 but not l4)
+        found = list(cli._find_meta_files_limited(tmp_path, max_depth=3))
+        found_names = {f.name for f in found}
+
+        assert "root.leann.meta.json" in found_names
+        assert "l1.leann.meta.json" in found_names
+        assert "l2.leann.meta.json" in found_names
+        assert "l3.leann.meta.json" in found_names
+        assert "l4.leann.meta.json" not in found_names
+
+    def test_find_meta_files_skips_node_modules(self, tmp_path: Path):
+        """Meta files inside node_modules should be skipped."""
+        from leann.cli import LeannCLI
+
+        cli = LeannCLI()
+
+        # Create a meta file inside node_modules
+        node_modules = tmp_path / "node_modules"
+        node_modules.mkdir()
+        (node_modules / "pkg.leann.meta.json").touch()
+
+        # Create a normal meta file
+        (tmp_path / "normal.leann.meta.json").touch()
+
+        found = list(cli._find_meta_files_limited(tmp_path, max_depth=3))
+        found_names = {f.name for f in found}
+
+        assert "normal.leann.meta.json" in found_names
+        assert "pkg.leann.meta.json" not in found_names
+
+    def test_find_meta_files_skips_hidden_dirs(self, tmp_path: Path):
+        """Meta files inside hidden directories (except .leann) should be skipped."""
+        from leann.cli import LeannCLI
+
+        cli = LeannCLI()
+
+        # Create meta files in hidden directories
+        hidden = tmp_path / ".hidden"
+        hidden.mkdir()
+        (hidden / "hidden.leann.meta.json").touch()
+
+        # .leann should NOT be skipped
+        leann_dir = tmp_path / ".leann"
+        leann_dir.mkdir()
+        (leann_dir / "leann.leann.meta.json").touch()
+
+        # Normal file
+        (tmp_path / "normal.leann.meta.json").touch()
+
+        found = list(cli._find_meta_files_limited(tmp_path, max_depth=3))
+        found_names = {f.name for f in found}
+
+        assert "normal.leann.meta.json" in found_names
+        assert "leann.leann.meta.json" in found_names
+        assert "hidden.leann.meta.json" not in found_names
+
+    def test_find_meta_files_skips_venv(self, tmp_path: Path):
+        """Meta files inside .venv and venv should be skipped."""
+        from leann.cli import LeannCLI
+
+        cli = LeannCLI()
+
+        # Create meta files in virtual env directories
+        for venv_name in [".venv", "venv", ".env", "env"]:
+            venv_dir = tmp_path / venv_name
+            venv_dir.mkdir()
+            (venv_dir / f"{venv_name}.leann.meta.json").touch()
+
+        # Normal file
+        (tmp_path / "normal.leann.meta.json").touch()
+
+        found = list(cli._find_meta_files_limited(tmp_path, max_depth=3))
+        found_names = {f.name for f in found}
+
+        assert "normal.leann.meta.json" in found_names
+        assert ".venv.leann.meta.json" not in found_names
+        assert "venv.leann.meta.json" not in found_names
+        assert ".env.leann.meta.json" not in found_names
+        assert "env.leann.meta.json" not in found_names
+
+    def test_find_meta_files_skips_build_dirs(self, tmp_path: Path):
+        """Meta files inside build/dist directories should be skipped."""
+        from leann.cli import LeannCLI
+
+        cli = LeannCLI()
+
+        # Create meta files in build directories
+        for build_name in ["build", "dist", "__pycache__", ".cache"]:
+            build_dir = tmp_path / build_name
+            build_dir.mkdir()
+            (build_dir / f"{build_name}.leann.meta.json").touch()
+
+        # Normal file
+        (tmp_path / "normal.leann.meta.json").touch()
+
+        found = list(cli._find_meta_files_limited(tmp_path, max_depth=3))
+        found_names = {f.name for f in found}
+
+        assert "normal.leann.meta.json" in found_names
+        assert "build.leann.meta.json" not in found_names
+        assert "dist.leann.meta.json" not in found_names
+        assert "__pycache__.leann.meta.json" not in found_names
+        assert ".cache.leann.meta.json" not in found_names
+
+
+class TestRegistryLimitedSearch:
+    """Test the registry limited search functionality."""
+
+    def test_has_app_indexes_limited_respects_depth(self, tmp_path: Path):
+        """Should not find indexes beyond max_depth."""
+        from leann.registry import _has_app_indexes_limited
+
+        # Create a deep directory structure
+        level4 = tmp_path / "l1" / "l2" / "l3" / "l4"
+        level4.mkdir(parents=True)
+
+        # Only create a file beyond depth 3
+        (level4 / "deep.leann.meta.json").touch()
+
+        # Should not find it with max_depth=3
+        assert not _has_app_indexes_limited(tmp_path, max_depth=3)
+
+        # Create one at depth 2
+        (tmp_path / "l1" / "l2" / "shallow.leann.meta.json").touch()
+
+        # Now should find it
+        assert _has_app_indexes_limited(tmp_path, max_depth=3)
+
+    def test_has_app_indexes_limited_skips_node_modules(self, tmp_path: Path):
+        """Should skip node_modules directory."""
+        from leann.registry import _has_app_indexes_limited
+
+        # Create a meta file inside node_modules
+        node_modules = tmp_path / "node_modules"
+        node_modules.mkdir()
+        (node_modules / "pkg.leann.meta.json").touch()
+
+        # Should not find it
+        assert not _has_app_indexes_limited(tmp_path, max_depth=3)
+
+        # Create a normal meta file
+        (tmp_path / "normal.leann.meta.json").touch()
+
+        # Now should find it
+        assert _has_app_indexes_limited(tmp_path, max_depth=3)
+
+
+class TestDiscoverIndexesPerformance:
+    """Test that _discover_indexes_in_project uses limited search."""
+
+    def test_discover_indexes_skips_deep_directories(self, tmp_path: Path):
+        """Should not scan directories beyond max_depth."""
+        from leann.cli import LeannCLI
+
+        cli = LeannCLI()
+
+        # Create a CLI format index (should always be found)
+        cli_indexes = tmp_path / ".leann" / "indexes" / "my-index"
+        cli_indexes.mkdir(parents=True)
+        (cli_indexes / "documents.leann.meta.json").touch()
+
+        # Create an app format index at depth 4 (should not be found)
+        deep_dir = tmp_path / "a" / "b" / "c" / "d"
+        deep_dir.mkdir(parents=True)
+        (deep_dir / "deep.leann.meta.json").touch()
+
+        indexes = cli._discover_indexes_in_project(tmp_path)
+
+        # Should find the CLI index
+        assert any(idx["name"] == "my-index" for idx in indexes)
+
+        # Should NOT find the deep app index
+        assert not any(idx["name"] == "d" for idx in indexes)


### PR DESCRIPTION
## Summary

Implements a centralized index registry at `~/.leann/indexes.json` that stores all LEANN index paths, enabling O(1) lookup instead of directory scanning.

## Changes

- Add `register_index`/`unregister_index`/`list_registered_indexes` functions in `registry.py`
- Update `leann build` to register indexes in global registry
- Update `leann list` to use registry when available (with scan fallback)
- Update `leann remove` to unregister indexes from registry
- Auto-cleanup stale registry entries on list
- Add comprehensive tests for registry functionality

## How it works

When registry is used, `leann list` output shows:
```
📊 Total: 3 indexes across 2 projects
⚡ Using global registry (O(1) lookup)
```

When falling back to scan (for legacy indexes):
```
📊 Total: 3 indexes across 2 projects
🔍 Using directory scan (run 'leann build' to enable fast registry)
```

## Test plan

- [x] Unit tests for registry functions (register/unregister/list)
- [x] Test stale entry cleanup
- [x] Test list_indexes uses registry when available
- [x] All 14 tests pass

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)