### PR TITLE
docs: Update repository URL in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,8 +21,8 @@ We welcome contributions! Leann is built by the community, for the community.
 
 2. **Clone the repository**:
    ```bash
-   git clone https://github.com/LEANN-RAG/LEANN-RAG.git
-   cd LEANN-RAG
+   git clone https://github.com/yichuan-w/LEANN.git leann
+   cd leann
    ```
 
 3. **Install system dependencies**:


### PR DESCRIPTION
This PR updates documentation only.
Updates clone instructions to use the correct repository URL (yichuan-w/LEANN) instead of the old LEANN-RAG organization URL.

## Checklist

- [x] Tests pass (`uv run pytest`)
- [x] Code formatted (`ruff format` and `ruff check`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
