### PR TITLE
feat: allow batch_size override via provider_options

### DIFF
--- a/packages/leann-core/src/leann/embedding_compute.py
+++ b/packages/leann-core/src/leann/embedding_compute.py
@@ -336,6 +336,11 @@ def compute_embeddings(
     """
     provider_options = provider_options or {}
 
+    # Allow batch_size override from provider_options (disables adaptive_optimization)
+    if "batch_size" in provider_options:
+        batch_size = provider_options["batch_size"]
+        adaptive_optimization = False  # User-specified batch_size takes precedence
+
     if mode == "sentence-transformers":
         return compute_embeddings_sentence_transformers(
             texts,


### PR DESCRIPTION
## Summary

- Add `batch_size` parameter support in `provider_options`/`embedding_options`
- Remove hardcoded `Qwen3-Embedding` batch_size override from `compute_embeddings_sentence_transformers`
- Model-specific batch sizes should now be configured via presets or user configuration

## Motivation

Different embedding models have different optimal batch sizes depending on:
- Model memory footprint
- User's GPU memory capacity
- Hardware configuration

Hardcoding model-specific batch sizes is inflexible. This change allows users and presets to configure batch_size dynamically.

## Usage

```python
builder = LeannBuilder(
    backend_name="hnsw",
    embedding_model="Qwen/Qwen3-Embedding-0.6B",
    embedding_mode="sentence-transformers",
    embedding_options={
        "batch_size": 32,  # Now configurable!
    }
)
```

## Test plan

- [x] Verify batch_size override works via provider_options
- [x] Verify default batch_size behavior unchanged when not specified