### PR TITLE
Fix Gemini OpenAI-compat embedding batch size limit

### DIFF
--- a/packages/leann-core/src/leann/embedding_compute.py
+++ b/packages/leann-core/src/leann/embedding_compute.py
@@ -778,7 +778,10 @@ def compute_embeddings_openai(
     #   "BatchEmbedContentsRequest.requests: at most 100 requests can be in one batch"
     if "generativelanguage.googleapis.com" in (resolved_base_url or ""):
         max_batch_size = min(max_batch_size, 100)
-        logger.info("Detected Gemini OpenAI-compatible base_url; capping embedding batch_size to %d.", max_batch_size)
+        logger.info(
+            "Detected Gemini OpenAI-compatible base_url; capping embedding batch_size to %d.",
+            max_batch_size,
+        )
 
     # if avg len is less than 1000, use the max batch size
 

--- a/tests/test_embedding_prompt_template.py
+++ b/tests/test_embedding_prompt_template.py
@@ -197,7 +197,9 @@ class TestPromptTemplatePrepending:
         # Verify result shape
         assert result.shape[0] == 1000, "Should return embeddings for all texts"
 
-    def test_gemini_openai_compat_caps_batch_size_to_100(self, mock_openai_module, mock_openai_client):
+    def test_gemini_openai_compat_caps_batch_size_to_100(
+        self, mock_openai_module, mock_openai_client
+    ):
         texts = [f"Doc {i}" for i in range(250)]
         provider_options = {"base_url": "https://generativelanguage.googleapis.com/v1beta/openai"}
 
@@ -213,7 +215,10 @@ class TestPromptTemplatePrepending:
 
         # Should chunk into <=100 inputs per request.
         assert mock_openai_client.embeddings.create.call_count == 3
-        batch_sizes = [len(call.kwargs["input"]) for call in mock_openai_client.embeddings.create.call_args_list]
+        batch_sizes = [
+            len(call.kwargs["input"])
+            for call in mock_openai_client.embeddings.create.call_args_list
+        ]
         assert batch_sizes == [100, 100, 50]
         assert result.shape[0] == 250
 


### PR DESCRIPTION
Gemini's OpenAI-compatible embedding endpoint rejects >100 inputs per request ("BatchEmbedContentsRequest.requests: at most 100 requests can be in one batch").

This PR:
- Caps OpenAI-compat embedding batch size to 100 when base_url points at generativelanguage.googleapis.com.
- Removes stray debug prints.
- Adds a unit test verifying chunking [100, 100, 50] for 250 inputs.

Repro:
```bash
leann build my-index ./docs \
  --embedding-mode openai \
  --embedding-api-base https://generativelanguage.googleapis.com/v1beta/openai \
  --embedding-model gemini-embedding-001
```
