### PR TITLE
Fix Docker installation: make backends optional, add build instruction

### DIFF
--- a/packages/leann/README.md
+++ b/packages/leann/README.md
@@ -4,9 +4,82 @@ LEANN is a revolutionary vector database that democratizes personal AI. Transfor
 
 ## Installation
 
+### Standard Installation (Local Development)
+
 ```bash
-# Default installation (includes both HNSW and DiskANN backends)
-uv pip install leann
+# Install core package only
+pip install leann
+
+# Or install with backends (requires building from source)
+# See "Building from Source" section below
+```
+
+### Docker Installation
+
+The backend packages (`leann-backend-hnsw` and `leann-backend-diskann`) require compilation and are not available on PyPI. For Docker installations, you have two options:
+
+#### Option 1: Install Core Only (No Backends)
+
+```dockerfile
+FROM python:3.11-slim
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install LEANN core
+RUN pip install leann
+
+# Note: Backends must be built from source (see Option 2)
+```
+
+#### Option 2: Build Backends from Source
+
+```dockerfile
+FROM python:3.11-slim
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    swig \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone LEANN repository
+WORKDIR /app
+RUN git clone https://github.com/yichuan-w/LEANN.git .
+
+# Install core first
+RUN pip install ./packages/leann-core
+
+# Build and install HNSW backend
+RUN pip install ./packages/leann-backend-hnsw
+
+# Build and install DiskANN backend (optional)
+RUN pip install ./packages/leann-backend-diskann
+```
+
+### Building from Source (Local)
+
+If you need the backends and they're not available as pre-built wheels:
+
+```bash
+# Clone the repository
+git clone https://github.com/yichuan-w/LEANN.git
+cd LEANN
+
+# Install core
+pip install ./packages/leann-core
+
+# Build and install HNSW backend
+pip install ./packages/leann-backend-hnsw
+
+# Build and install DiskANN backend (optional)
+pip install ./packages/leann-backend-diskann
 ```
 
 ## Quick Start

--- a/packages/leann/pyproject.toml
+++ b/packages/leann/pyproject.toml
@@ -24,15 +24,25 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 
-# Default installation: core + hnsw + diskann
+# Core package only - backends must be installed separately or built from source
+# Backends require compilation and are not available on PyPI
 dependencies = [
     "leann-core>=0.1.0",
-    "leann-backend-hnsw>=0.1.0",
-    "leann-backend-diskann>=0.1.0",
 ]
 
 [project.optional-dependencies]
-# All backends now included by default
+# Backend packages require compilation and must be built from source
+# See installation instructions in README for Docker/source builds
+hnsw = [
+    "leann-backend-hnsw>=0.1.0",
+]
+diskann = [
+    "leann-backend-diskann>=0.1.0",
+]
+all = [
+    "leann-backend-hnsw>=0.1.0",
+    "leann-backend-diskann>=0.1.0",
+]
 
 [project.urls]
 Repository = "https://github.com/yichuan-w/LEANN"


### PR DESCRIPTION
## What does this PR do?

Makes backend dependencies (`leann-backend-hnsw` and `leann-backend-diskann`) optional in the `leann` meta package. These backends require compilation and aren't on PyPI, which caused Docker installs to fail with `ResolutionImpossible`.

Now:
- `pip install leann` installs only `leann-core` (works in Docker)
- Backends are available as optional extras: `leann[hnsw]`, `leann[diskann]`, or `leann[all]`
- Users can build backends from source when needed

This fixes Docker installations where backends can't be resolved from PyPI.

## Related Issues

Fixes #210

## Checklist

- [ ] Tests pass (`uv run pytest`)
- [ ] Code formatted (`ruff format` and `ruff check`)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)