### PR TITLE
Relax transformers pin for Py>=3.10

### DIFF
--- a/packages/leann-core/pyproject.toml
+++ b/packages/leann-core/pyproject.toml
@@ -25,9 +25,9 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "openai>=1.0.0",
     "huggingface-hub>=0.20.0",
-    # Keep transformers below 4.46: 4.46.0 adds Python 3.10-only return type syntax and
-    # breaks Python 3.9 environments.
-    "transformers>=4.30.0,<4.46",
+    # Keep Py3.9 compatible below 4.46; allow newer for Py>=3.10 (e.g., ColQwen/ColPali).
+    "transformers>=4.30.0,<4.46; python_version < '3.10'",
+    "transformers>=4.53.1,<4.58; python_version >= '3.10'",
     "requests>=2.25.0",
     "accelerate>=0.20.0",
     "PyPDF2>=3.0.0",
@@ -42,7 +42,8 @@ dependencies = [
 [project.optional-dependencies]
 colab = [
     "torch>=2.0.0,<3.0.0",  # Limit torch version to avoid conflicts
-    "transformers>=4.30.0,<4.46",  # 4.46.0 switches to PEP 604 typing (int | None), breaks Py3.9
+    "transformers>=4.30.0,<4.46; python_version < '3.10'",  # Py3.9 compatibility
+    "transformers>=4.53.1,<4.58; python_version >= '3.10'",
     "accelerate>=0.20.0,<1.0.0",  # Limit accelerate version
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,9 @@ dependencies = [
     "ollama",
     "requests>=2.25.0",
     "sentence-transformers>=3.0.0",
-    # Pin transformers below 4.46: 4.46.0 introduced Python 3.10-only typing (PEP 604) and
-    # breaks our Python 3.9 test matrix when pulled in by sentence-transformers.
-    "transformers<4.46",
+    # Keep Py3.9 compatible below 4.46; allow newer for Py>=3.10 (e.g., ColQwen/ColPali).
+    "transformers<4.46; python_version < '3.10'",
+    "transformers>=4.53.1,<4.58; python_version >= '3.10'",
     "openai>=1.0.0",
     # PDF parsing dependencies - essential for document processing
     "PyPDF2>=3.0.0",


### PR DESCRIPTION
## Summary
- Keep transformers <4.46 for Python 3.9 compatibility.
- Allow transformers >=4.53.1,<4.58 for Python >=3.10 to support ColQwen/ColPali.

## Rationale
- LEANN currently pins transformers <4.46 to avoid Py3.9 typing incompatibilities.
- ColPali/ColQwen models require newer transformers; this keeps Py3.9 safe while unblocking modern stacks.