### PR TITLE
feat: add `leann watch` command, line numbers in code search, and fix search output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ apps/multimodal/vision-based-pdf-multi-vector/multi-vector-colpali-native-weavia
 
 # AUR build directory (Arch Linux)
 paru-bin/
+merkle-tree-test/
+*.pickle

--- a/README.md
+++ b/README.md
@@ -1082,6 +1082,9 @@ leann ask my-docs --interactive
 # Ask a single question (non-interactive)
 leann ask my-docs "Where are prompts configured?"
 
+# Detect file changes since last build/watch checkpoint
+leann watch my-docs
+
 # List all your indexes
 leann list
 
@@ -1093,6 +1096,7 @@ leann remove my-docs
 - Auto-detects document formats (PDF, TXT, MD, DOCX, PPTX + code files)
 - **🧠 AST-aware chunking** for Python, Java, C#, TypeScript files
 - Smart text chunking with overlap for all other content
+- **📂 File change detection** via Merkle tree snapshots (`leann watch`)
 - Multiple LLM providers (Ollama, OpenAI, HuggingFace)
 - Organized index storage in `.leann/indexes/` (project-local)
 - Support for advanced search parameters
@@ -1100,7 +1104,7 @@ leann remove my-docs
 <details>
 <summary><strong>📋 Click to expand: Complete CLI Reference</strong></summary>
 
-You can use `leann --help`, or `leann build --help`, `leann search --help`, `leann ask --help`, `leann list --help`, `leann remove --help` to get the complete CLI reference.
+You can use `leann --help`, or `leann build --help`, `leann search --help`, `leann watch --help`, `leann ask --help`, `leann list --help`, `leann remove --help` to get the complete CLI reference.
 
 **Build Command:**
 ```bash
@@ -1125,6 +1129,24 @@ Options:
   --complexity N                Search complexity (default: 64)
   --recompute / --no-recompute  Enable/disable embedding recomputation (default: enabled). Should not do a `no-recompute` search in a `recompute` build.
   --pruning-strategy {global,local,proportional}
+```
+
+**Watch Command:**
+```bash
+leann watch INDEX_NAME
+
+# Compares the current file system state against the last checkpoint (Merkle tree snapshot)
+# and reports which files have been added, removed, or modified, along with their chunk IDs.
+#
+# - Automatically saves a new checkpoint after detecting changes
+# - Each subsequent run compares against the most recent checkpoint
+# - File change detection uses SHA-256 content hashing via a Merkle tree
+#
+# Example output:
+#   === Changes since last checkpoint ===
+#   modified (1):
+#     - /path/to/file.py
+#       chunks: 42, 43, 44
 ```
 
 **Ask Command:**

--- a/packages/leann-core/src/leann/sync.py
+++ b/packages/leann-core/src/leann/sync.py
@@ -18,6 +18,7 @@ def hash_data(data: str | bytes):
 
 @dataclass
 class MerkleTreeNode:
+    ## TODO: this merkle tree only has two layer, need to improve if we want to scale to large codebase
     hash: str
     data: str
     children: dict[str, "MerkleTreeNode"] = field(default_factory=dict)
@@ -93,11 +94,13 @@ class FileSynchronizer:
             recursive=True,
             exclude=self.ignore_patterns,
             required_exts=self.include_extensions,
-            exclude_empty=True,
+            exclude_empty=False,
         )
+        # print('reader.iter_data() length', len(list(reader.iter_data())))
 
         for file in reader.iter_data():
             if len(file) > 1:
+                # print('file length is greater than 1', file)
                 continue  # SimpleDirectoryReader can load more than 1 documents for weird file types e.g. PDFs
             file = file[0]
             try:


### PR DESCRIPTION
## Summary

- **`leann watch` command**: Compares the current file system state against the last Merkle tree checkpoint and reports added/removed/modified files along with their associated chunk IDs. Integrates with `leann build` to automatically create initial snapshots and persist sync config.
- **Line numbers in code chunks**: Code files now have line numbers prepended to each line (e.g. `42|def foo():`) during chunking, so search results show exact line locations for easy code navigation. Partial first lines from chunk overlap are trimmed to keep output clean.
- **Fix search output being swallowed**: `suppress_cpp_output` was redirecting OS-level stdout/stderr to `/dev/null` to silence HNSW/FAISS C++ logs, but this also silenced Python `print()`. Fixed by pointing `sys.stdout`/`sys.stderr` at saved fd copies so Python output reaches the terminal while C++ output is still suppressed.
- **README updates**: Added `leann watch` documentation to the feature list, Usage Examples, and Complete CLI Reference.

## Test plan

- [ ] `leann build test-idx --docs ./some-dir --no-recompute` creates index + `sync_roots.json` + `.sync_context.pickle`
- [ ] `leann watch test-idx` shows "No changes detected" immediately after build
- [ ] Modify a file, then `leann watch test-idx` shows it as modified with chunk IDs
- [ ] `leann search test-idx "query" --no-recompute` displays search results (not swallowed) with line numbers in code chunks
- [ ] Verify code chunks start at clean line boundaries (no partial first lines)