### PR TITLE
fix: AST chunking line numbers and index existence check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,4 +110,5 @@ apps/multimodal/vision-based-pdf-multi-vector/multi-vector-colpali-native-weavia
 # AUR build directory (Arch Linux)
 paru-bin/
 merkle-tree-test/
+test-code/
 *.pickle

--- a/apps/base_rag_example.py
+++ b/apps/base_rag_example.py
@@ -391,7 +391,7 @@ class BaseRAGExample(ABC):
 
         # Check if index exists
         index_path = str(Path(args.index_dir) / f"{self.default_index_name}.leann")
-        index_exists = Path(args.index_dir).exists()
+        index_exists = Path(f"{index_path}.meta.json").exists()
 
         if not index_exists or args.force_rebuild:
             # Load data and build index


### PR DESCRIPTION
## Summary

- **Remove erroneous first-line trimming in `create_ast_chunks`**: The previous logic stripped any first line not starting with a digit, incorrectly removing function signatures like `def hello():`, `class Foo:`, etc.
- **Move line number prepending from before to after AST chunking**: Previously, line numbers were prepended to source code before the AST parser, turning `def hello():` into `1|def hello():` which broke syntax tree parsing and caused the chunker to fall back to naive text splitting (chunks starting mid-function). Now AST chunking runs on clean source code, and line numbers are added afterward using `start_line_no` from chunk metadata.
- **Fix index existence check in `base_rag_example.py`**: Changed from checking if the directory exists (`Path(args.index_dir).exists()`) to checking if the actual index metadata file exists (`Path(f"{index_path}.meta.json").exists()`), since empty temp directories always exist and would skip index building.

## Test plan

- [x] All 25 tests in `test_astchunk_integration.py` pass (previously 7 unit tests + 2 integration tests failed)
- [x] Pre-commit hooks (ruff format/lint) pass