### PR TITLE
perf: skip unnecessary rglob scan in register_project_directory when CLI indexes exist

### DIFF
--- a/packages/leann-core/src/leann/registry.py
+++ b/packages/leann-core/src/leann/registry.py
@@ -63,12 +63,10 @@ def register_project_directory(project_dir: Optional[Union[str, Path]] = None):
     else:
         project_dir = Path(project_dir)
 
-    # Only register directories that have some kind of LEANN content
-    # Either .leann/indexes/ (CLI format) or *.leann.meta.json files (apps format)
+    # Only register directories that have some kind of LEANN content.
+    # Check CLI-format first to avoid an expensive rglob on large directories.
     has_cli_indexes = (project_dir / ".leann" / "indexes").exists()
-    has_app_indexes = any(project_dir.rglob("*.leann.meta.json"))
-
-    if not (has_cli_indexes or has_app_indexes):
+    if not has_cli_indexes and not any(project_dir.rglob("*.leann.meta.json")):
         # Don't register if there are no LEANN indexes
         return
 


### PR DESCRIPTION
## Problem

`register_project_directory()` unconditionally evaluated both conditions:

```python
has_cli_indexes = (project_dir / ".leann" / "indexes").exists()
has_app_indexes = any(project_dir.rglob("*.leann.meta.json"))  # always runs
```

Because Python evaluates all assignments eagerly, `any(project_dir.rglob(...))` was always called — even when `has_cli_indexes` was already `True`. On large project roots (e.g. `$HOME`), this triggered a full recursive filesystem scan on every `leann build` invocation, even though the result was ignored when CLI-format indexes were detected.

This issue was related to the same class of problem reported in #122 ("leann list scans all the things"), but manifested during `leann build` rather than `leann list`.

## Solution

Short-circuit the check: only run the `rglob` when `has_cli_indexes` is `False`.

```python
has_cli_indexes = (project_dir / ".leann" / "indexes").exists()
if not has_cli_indexes and not any(project_dir.rglob("*.leann.meta.json")):
    return
```

This has no effect on correctness:
- If CLI indexes exist → register the directory (same as before).
- If no CLI indexes → fall through to the `rglob` scan to check for app-format indexes (same as before).
- Projects with both CLI and app-format indexes → registered via the CLI check; app-format indexes are still discovered during `leann list` via `_discover_indexes_in_project`.

## Testing

Manual verification: ran `leann build` from a large directory and confirmed the rglob is no longer triggered when `.leann/indexes/` exists.