### PR TITLE
fix(server, interactive): resolve pydantic ForwardRef and readline hi…

### DIFF
--- a/packages/leann-core/src/leann/interactive_utils.py
+++ b/packages/leann-core/src/leann/interactive_utils.py
@@ -73,7 +73,7 @@ class InteractiveSession:
         try:
             rl.read_history_file(str(history_file))
             rl.set_history_length(1000)
-        except FileNotFoundError:
+        except (FileNotFoundError, FileExistsError, OSError):
             pass
 
         # Save history on exit

--- a/packages/leann-core/src/leann/server.py
+++ b/packages/leann-core/src/leann/server.py
@@ -19,8 +19,28 @@ import os
 from pathlib import Path
 from typing import Any
 
+from pydantic import BaseModel as _BaseModel
+
 from .api import LeannSearcher
 from .cli import LeannCLI
+
+
+class SearchRequest(_BaseModel):
+    query: str
+    top_k: int = 5
+    complexity: int = 64
+    beam_width: int = 1
+    prune_ratio: float = 0.0
+    recompute_embeddings: bool = True
+    pruning_strategy: str = "global"
+    use_grep: bool = False
+
+
+class SearchResultModel(_BaseModel):
+    id: str
+    score: float
+    text: str
+    metadata: dict[str, Any]
 
 
 def _ensure_fastapi():
@@ -94,22 +114,6 @@ def create_app():
     """
 
     FastAPI, HTTPException, BaseModel = _ensure_fastapi()
-
-    class SearchRequest(BaseModel):
-        query: str
-        top_k: int = 5
-        complexity: int = 64
-        beam_width: int = 1
-        prune_ratio: float = 0.0
-        recompute_embeddings: bool = True
-        pruning_strategy: str = "global"
-        use_grep: bool = False
-
-    class SearchResultModel(BaseModel):
-        id: str
-        score: float
-        text: str
-        metadata: dict[str, Any]
 
     app = FastAPI(
         title="LEANN Vector DB Server",


### PR DESCRIPTION
This pull request refactors how Pydantic models are defined and improves error handling in the interactive utilities. The main change is moving the `SearchRequest` and `SearchResultModel` Pydantic models to the module level, which helps with code organization and potentially improves import performance. Additionally, the error handling in `setup_readline` is made more robust.

**Pydantic model refactoring:**

* Moved the definitions of the `SearchRequest` and `SearchResultModel` Pydantic models from inside the `create_app` function to the module level in `server.py`, and updated them to inherit from an internal alias `_BaseModel`. This improves code clarity and avoids repeated class definitions on each app creation. [[1]](diffhunk://#diff-275f263fd804b334818ad8fe60ce15e43310cde2be2c710e06ef983ad13af8dbR22-R45) [[2]](diffhunk://#diff-275f263fd804b334818ad8fe60ce15e43310cde2be2c710e06ef983ad13af8dbL98-L113)

**Error handling improvements:**

* Broadened the exception handling in `setup_readline` to also catch `FileExistsError` and `OSError` in addition to `FileNotFoundError`, making history file loading more robust.