### PR TITLE
test: verify daemon isolation across different passages files (fixes #281)

### DIFF
--- a/packages/leann-core/src/leann/registry.py
+++ b/packages/leann-core/src/leann/registry.py
@@ -63,12 +63,10 @@ def register_project_directory(project_dir: Optional[Union[str, Path]] = None):
     else:
         project_dir = Path(project_dir)
 
-    # Only register directories that have some kind of LEANN content
-    # Either .leann/indexes/ (CLI format) or *.leann.meta.json files (apps format)
+    # Only register directories that have some kind of LEANN content.
+    # Check CLI-format first to avoid an expensive rglob on large directories.
     has_cli_indexes = (project_dir / ".leann" / "indexes").exists()
-    has_app_indexes = any(project_dir.rglob("*.leann.meta.json"))
-
-    if not (has_cli_indexes or has_app_indexes):
+    if not has_cli_indexes and not any(project_dir.rglob("*.leann.meta.json")):
         # Don't register if there are no LEANN indexes
         return
 

--- a/tests/test_embedding_server_manager.py
+++ b/tests/test_embedding_server_manager.py
@@ -489,6 +489,141 @@ def test_registry_record_write_is_atomic(tmp_path, monkeypatch):
     assert dst.endswith(".json")
 
 
+def test_different_passages_files_start_separate_daemons(tmp_path, monkeypatch):
+    """Two managers with different passages files must NOT share a daemon (issue #281).
+
+    Simulates sequential test runs where each test builds its own index in a
+    separate directory but uses the same model and embedding mode.  A stale
+    daemon from run A should never be adopted by run B.
+    """
+    registry_dir = tmp_path / "servers"
+    registry_dir.mkdir()
+    monkeypatch.setattr(EmbeddingServerManager, "_registry_dir", staticmethod(lambda: registry_dir))
+
+    # Each call to _get_available_port returns a strictly increasing port so
+    # that the two daemons land on different ports when they are not sharing.
+    port_seq = [6200]
+
+    def fake_get_available_port(start_port):
+        p = port_seq[0]
+        port_seq[0] += 1
+        return p
+
+    monkeypatch.setattr(
+        "leann.embedding_server_manager._get_available_port",
+        fake_get_available_port,
+    )
+
+    alive_pids: set[int] = set()
+    monkeypatch.setattr(
+        "leann.embedding_server_manager._pid_is_alive", lambda pid: pid in alive_pids
+    )
+    monkeypatch.setattr("leann.embedding_server_manager._check_port", lambda port: True)
+
+    pid_seq = [55001]
+    starts: list[dict] = []
+
+    def fake_start_new_server(self, port, model_name, embedding_mode, **kwargs):
+        pid = pid_seq[0]
+        pid_seq[0] += 1
+        alive_pids.add(pid)
+        starts.append({"port": port, "config": kwargs.get("config_signature")})
+        self.server_process = DummyProcess(pid=pid)
+        self.server_port = port
+        self._server_config = kwargs.get("config_signature")
+        return True, port
+
+    monkeypatch.setattr(EmbeddingServerManager, "_start_new_server", fake_start_new_server)
+
+    # Simulate two separate test runs, each in its own temp subdirectory,
+    # using the *same* filename patterns but *different* parent directories.
+    run_a = tmp_path / "run_a"
+    run_a.mkdir()
+    meta_a = run_a / "myindex.meta.json"
+    passages_a = run_a / "myindex.passages.jsonl"
+    passages_a.write_text("passage: hello world\n", encoding="utf-8")
+    _write_meta(meta_a, passages_a.name, "myindex.passages.idx", total=1)
+
+    run_b = tmp_path / "run_b"
+    run_b.mkdir()
+    meta_b = run_b / "myindex.meta.json"
+    passages_b = run_b / "myindex.passages.jsonl"
+    passages_b.write_text("passage: different content\n", encoding="utf-8")
+    _write_meta(meta_b, passages_b.name, "myindex.passages.idx", total=1)
+
+    # Run A: start daemon with index_a passages
+    manager_a = EmbeddingServerManager("leann_backend_hnsw.hnsw_embedding_server")
+    ok_a, port_a = manager_a.start_server(
+        port=6200,
+        model_name="test-model",
+        passages_file=str(meta_a),
+        use_daemon=True,
+    )
+    assert ok_a
+    assert len(starts) == 1, "First manager should start one daemon"
+
+    # Run B: a fresh manager with a DIFFERENT passages file must not adopt run A's daemon
+    manager_b = EmbeddingServerManager("leann_backend_hnsw.hnsw_embedding_server")
+    ok_b, port_b = manager_b.start_server(
+        port=6200,
+        model_name="test-model",
+        passages_file=str(meta_b),
+        use_daemon=True,
+    )
+    assert ok_b
+    assert len(starts) == 2, (
+        "A separate daemon must be spawned for each distinct passages file; "
+        "sharing daemons across different indices causes 'Failed to fetch embeddings' errors"
+    )
+    assert port_a != port_b, "Each index must communicate with its own daemon port"
+
+
+def test_same_passages_file_reuses_existing_daemon(tmp_path, monkeypatch):
+    """Two managers with identical passages files SHOULD share the same daemon."""
+    registry_dir = tmp_path / "servers"
+    registry_dir.mkdir()
+    monkeypatch.setattr(EmbeddingServerManager, "_registry_dir", staticmethod(lambda: registry_dir))
+    monkeypatch.setattr(
+        "leann.embedding_server_manager._get_available_port", lambda start_port: start_port
+    )
+
+    alive_pids: set[int] = {99001}
+    monkeypatch.setattr(
+        "leann.embedding_server_manager._pid_is_alive", lambda pid: pid in alive_pids
+    )
+    monkeypatch.setattr("leann.embedding_server_manager._check_port", lambda port: True)
+
+    starts: list[int] = []
+
+    def fake_start_new_server(self, port, model_name, embedding_mode, **kwargs):
+        starts.append(port)
+        self.server_process = DummyProcess(pid=99001)
+        self.server_port = port
+        self._server_config = kwargs.get("config_signature")
+        return True, port
+
+    monkeypatch.setattr(EmbeddingServerManager, "_start_new_server", fake_start_new_server)
+
+    meta = tmp_path / "shared.meta.json"
+    passages = tmp_path / "shared.passages.jsonl"
+    passages.write_text("shared passage\n", encoding="utf-8")
+    _write_meta(meta, passages.name, "shared.passages.idx", total=1)
+
+    manager1 = EmbeddingServerManager("leann_backend_hnsw.hnsw_embedding_server")
+    ok1, port1 = manager1.start_server(
+        port=6300, model_name="test-model", passages_file=str(meta), use_daemon=True
+    )
+    assert ok1 and len(starts) == 1
+
+    manager2 = EmbeddingServerManager("leann_backend_hnsw.hnsw_embedding_server")
+    ok2, port2 = manager2.start_server(
+        port=6300, model_name="test-model", passages_file=str(meta), use_daemon=True
+    )
+    assert ok2
+    assert len(starts) == 1, "Second manager should reuse the existing daemon, not start a new one"
+    assert port1 == port2, "Both managers should connect to the same daemon port"
+
+
 def test_stale_lock_info_removed_when_pid_dead(tmp_path, monkeypatch):
     registry_dir = tmp_path / "servers"
     registry_dir.mkdir()


### PR DESCRIPTION
Fixes #281

## Problem

When multiple DiskANN tests run sequentially in the same process, a daemonized embedding server started by test A could be incorrectly adopted by test B if the config-signature comparison did not include the passages file path and stat information. This caused the server to serve node IDs from index B while having index A's passages loaded, resulting in:

```
ZMQ_FETCH_ERROR: Server response has invalid dimensions size.
RuntimeError: Failed to fetch embeddings
```

## Solution

Added two regression tests to `test_embedding_server_manager.py` that directly exercise this scenario using the existing mock infrastructure (no real subprocesses or network):

- **`test_different_passages_files_start_separate_daemons`**: Two managers pointing to different passages files (simulating sequential pytest runs each in their own temp directory) must each spawn a separate daemon and use distinct ZMQ ports. Without `passages_file`/`passages_signature` in the config-signature hash key, both managers would map to the same registry file and the second would silently adopt the first daemon.

- **`test_same_passages_file_reuses_existing_daemon`**: The positive case — two managers for the *same* passages file should share the existing daemon (no duplicate spawning).

## Testing

```bash
pytest tests/test_embedding_server_manager.py -v
# 13 passed
```