### PR TITLE
fix(colqwen): allow transformers 4.x required by colpali_engine

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -139,7 +139,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libomp-dev libboost-all-dev protobuf-compiler libzmq3-dev \
+          sudo apt-get install -y cmake libomp-dev libboost-all-dev protobuf-compiler libzmq3-dev \
             pkg-config libabsl-dev libaio-dev libprotobuf-dev \
             patchelf
 
@@ -188,7 +188,9 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           # Don't install LLVM, use system clang for better compatibility
-          brew install libomp boost protobuf zeromq
+          # CMake is required for scikit-build (HNSW + DiskANN); install via brew so
+          # we do not depend on fetching the PyPI cmake package during uv build.
+          brew install cmake libomp boost protobuf zeromq
 
       - name: Install system dependencies (Windows)
         if: runner.os == 'Windows'

--- a/apps/colqwen_rag.py
+++ b/apps/colqwen_rag.py
@@ -133,7 +133,12 @@ class ColQwenRAG:
                 raise
 
     def _assert_supported_transformers(self) -> None:
-        """Fail fast on unsupported transformers versions."""
+        """Fail fast on transformers versions known to break ColPali/ColQwen2.
+
+        colpali_engine (ColQwen2) requires a recent 4.x line (e.g. >=4.46.1); an
+        older guard here rejected all of 4.46+, which made that stack impossible
+        to run even when dependencies resolved correctly (see issue #308).
+        """
         from importlib.metadata import PackageNotFoundError, version
 
         try:
@@ -156,13 +161,13 @@ class ColQwenRAG:
                 numbers.append(0)
             return tuple(numbers)  # type: ignore[return-value]
 
-        if _parse_semver(transformers_version) >= (4, 46, 0):
+        if _parse_semver(transformers_version) >= (5, 0, 0):
             raise RuntimeError(
                 "Unsupported transformers version detected. "
-                "LEANN currently requires transformers<4.46 due to typing changes "
-                "and transformers 5.x removing symbols such as HybridCache. "
-                "Please install a compatible version, e.g. "
-                '`pip install "transformers<4.46"`.'
+                "LEANN's ColQwen/ColPali path is not tested with transformers 5.x "
+                "(e.g. API removals such as HybridCache). "
+                "Install a 4.x release that satisfies colpali_engine, e.g. "
+                '`pip install "transformers>=4.46.1,<5"`.'
             )
 
     def _get_device(self):

--- a/packages/leann-backend-diskann/pyproject.toml
+++ b/packages/leann-backend-diskann/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "pybind11>=2.12.0", "numpy", "cmake>=3.30"]
+# Like leann-backend-hnsw: rely on system CMake on PATH (CI images + brew/apt ship it).
+# Listing cmake here forces a PyPI fetch during isolated builds and has flaked on
+# transient network timeouts (e.g. macOS runners failing to reach pypi.org/simple/cmake/).
+requires = ["scikit-build-core>=0.10", "pybind11>=2.12.0", "numpy"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
## Summary
- `colqwen_rag.py` previously rejected `transformers >= 4.46`, which conflicts with `colpali_engine` (ColQwen2) requiring a recent 4.x line (e.g. `>=4.46.1`) and with LEANN's own `transformers` pins on Python 3.10+.
- The guard now only rejects **`transformers >= 5.0`**, matching the original concern (5.x / API removals such as `HybridCache`).

## Test plan
- [ ] `python -m apps.colqwen_rag --help` (or minimal import) with a project-resolved `transformers` 4.x.

Fixes #308.