### PR TITLE
fix(cli): use sys.stdout.flush for JSON search on Windows

### DIFF
--- a/packages/leann-core/src/leann/cli.py
+++ b/packages/leann-core/src/leann/cli.py
@@ -2669,10 +2669,7 @@ Examples:
             )
         finally:
             if json_mode:
-                import ctypes
-
-                libc = ctypes.CDLL(None)
-                libc.fflush(None)
+                sys.stdout.flush()
                 os.dup2(saved_fd, 1)
                 os.close(saved_fd)
 


### PR DESCRIPTION
ctypes.CDLL(None) is Unix-only; Windows raises TypeError when MCP/CLI runs search in JSON mode (see #310).

## What does this PR do?

<!-- Brief description of your changes -->

## Related Issues

Fixes #

## Checklist

- [ ] Tests pass (`uv run pytest`)
- [ ] Code formatted (`ruff format` and `ruff check`)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
