### PR TITLE
fix(cli): Windows crash in search_documents JSON mode

### DIFF
--- a/packages/leann-core/src/leann/cli.py
+++ b/packages/leann-core/src/leann/cli.py
@@ -2669,10 +2669,7 @@ Examples:
             )
         finally:
             if json_mode:
-                import ctypes
-
-                libc = ctypes.CDLL(None)
-                libc.fflush(None)
+                sys.stdout.flush()
                 os.dup2(saved_fd, 1)
                 os.close(saved_fd)
 


### PR DESCRIPTION
## Summary

- Replace Unix-specific `ctypes.CDLL(None)` / `libc.fflush(None)` with cross-platform `sys.stdout.flush()` in the `search_documents` finally block

Fixes #310

## Root Cause

`ctypes.CDLL(None)` loads libc on Unix but raises `TypeError` on Windows because `None` is not a valid DLL name. The call was used to flush the C-level stdout buffer before restoring the original fd, but `sys.stdout.flush()` achieves the same effect cross-platform.

## Test plan

- [ ] Verify `leann search` in JSON mode still works on Unix (stdout suppression + restore)
- [ ] Verify `leann search` in JSON mode no longer crashes on Windows