### PR TITLE
feat(browser_rag): put url/domain/visit fields in metadata so they're filterable

### DIFF
--- a/apps/history_data/history.py
+++ b/apps/history_data/history.py
@@ -2,6 +2,7 @@ import os
 import sqlite3
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from llama_index.core import Document
 from llama_index.core.readers.base import BaseReader
@@ -77,6 +78,7 @@ class ChromeHistoryReader(BaseReader):
                 last_visit, url, title, visit_count, typed_count, _hidden = row
 
                 # Create document content with metadata embedded in text
+                # (kept in body so semantic search still sees these fields)
                 doc_content = f"""
 [Title]: {title}
 [URL of the page]: {url}
@@ -85,10 +87,21 @@ class ChromeHistoryReader(BaseReader):
 [Typed times]: {typed_count}
 """
 
-                # Create document with embedded metadata
-                doc = Document(text=doc_content, metadata={"title": title[0:150]})
-                # if len(title) > 150:
-                #     print(f"Title is too long: {title}")
+                # Also expose structured fields via metadata so they can be used
+                # with metadata_filters at search time (see docs/metadata_filtering.md).
+                domain = urlparse(url).netloc if url else ""
+
+                doc = Document(
+                    text=doc_content,
+                    metadata={
+                        "title": (title or "")[0:150],
+                        "url": url or "",
+                        "domain": domain,
+                        "last_visited": str(last_visit) if last_visit is not None else "",
+                        "visit_count": int(visit_count) if visit_count is not None else 0,
+                        "typed_count": int(typed_count) if typed_count is not None else 0,
+                    },
+                )
                 docs.append(doc)
                 count += 1
 

--- a/packages/leann-core/src/leann/chunking_utils.py
+++ b/packages/leann-core/src/leann/chunking_utils.py
@@ -312,16 +312,12 @@ def create_traditional_chunks(
 
     result = []
     for doc in documents:
-        # Extract document-level metadata
-        doc_metadata = {
-            "file_path": doc.metadata.get("file_path", ""),
-            "file_name": doc.metadata.get("file_name", ""),
-            "source": doc.metadata.get("source", ""),
-        }
-        if "creation_date" in doc.metadata:
-            doc_metadata["creation_date"] = doc.metadata["creation_date"]
-        if "last_modified_date" in doc.metadata:
-            doc_metadata["last_modified_date"] = doc.metadata["last_modified_date"]
+        # Propagate all document-level metadata to each chunk so custom fields
+        # (e.g. url/domain for browser_rag) remain available for metadata_filters.
+        doc_metadata = dict(doc.metadata) if doc.metadata else {}
+        doc_metadata.setdefault("file_path", "")
+        doc_metadata.setdefault("file_name", "")
+        doc_metadata.setdefault("source", "")
 
         try:
             nodes = node_parser.get_nodes_from_documents([doc])


### PR DESCRIPTION
## what

browser_rag stuffs url, last-visited, visit count etc into the chunk text. metadata dict only has title. so you can't filter by domain or date. doesn't match the pattern in `docs/metadata_filtering.md`.

this moves those fields into metadata. text body unchanged so existing indexes still embed the same.

also fixes a related issue in `create_traditional_chunks`: it was forwarding a fixed allowlist of keys, so any custom reader metadata got silently dropped at chunking time. now it forwards the whole dict.

**important — nothing is removed, this is strictly additive:**

```python
# before: 5 keys hardcoded, everything else dropped
doc_metadata = {"file_path": ..., "file_name": ..., "source": ...}
if "creation_date" in doc.metadata:        doc_metadata["creation_date"] = ...
if "last_modified_date" in doc.metadata:   doc_metadata["last_modified_date"] = ...

# after: whole dict copied, same 3 defaults guaranteed
doc_metadata = dict(doc.metadata) if doc.metadata else {}
doc_metadata.setdefault("file_path", "")
doc_metadata.setdefault("file_name", "")
doc_metadata.setdefault("source", "")
```

`creation_date` and `last_modified_date` still propagate — they get copied by `dict(doc.metadata)` automatically when present, which is why the explicit `if` blocks become redundant. the only difference is now `url`, `domain`, `visit_count` etc. also come through.

## why

want to do stuff like:

```python
searcher.search(
    "videos i watched",
    metadata_filters={"domain": {"==": "youtube.com"}, "last_visited": {">": "2026-04-01"}},
)
```

today: impossible. after this: works.

## test

built a 50-row test index off a snapshot of a real Chrome `History` db. confirmed `passages.jsonl` metadata now includes \`url\`, \`domain\`, \`last_visited\`, \`visit_count\`, \`typed_count\`. example:

\`\`\`json
{
  \"title\": \"AgentsView\",
  \"url\": \"http://127.0.0.1:8080/sessions/4fd7acc7-...\",
  \"domain\": \"127.0.0.1:8080\",
  \"last_visited\": \"2026-05-17 10:31:22\",
  \"visit_count\": 1,
  \"typed_count\": 0,
  \"file_path\": \"\",
  \"file_name\": \"\",
  \"source\": \"\"
}
\`\`\`

ran \`searcher.search(\"pages i visited\", top_k=10, metadata_filters={\"domain\": {\"==\": \"www.google.com\"}})\` — got 4 results, every one had \`domain=\"www.google.com\"\`. negative control with a bogus domain returned 0 results.

\`ruff format\` + \`ruff check\` clean on both files.

## not in scope

- re-embedding existing indexes (they keep working, just without the new filter fields until rebuilt)
- other rag apps that may also benefit (e.g. email_rag could expose sender/recipient/date) — flagging for follow-up if maintainers want
