### PR TITLE
fix: guard choices[0] and message=None before content access

### DIFF
--- a/benchmarks/financebench/evaluate_financebench.py
+++ b/benchmarks/financebench/evaluate_financebench.py
@@ -493,6 +493,8 @@ Respond with exactly one word: "CORRECT" if the generated answer is factually ac
                 max_tokens=10,
                 temperature=0,
             )
+            if not judge_response.choices or judge_response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             judgment = judge_response.choices[0].message.content.strip().upper()
             return judgment == "CORRECT"
         except Exception as e:


### PR DESCRIPTION
## Summary

In `benchmarks/financebench/evaluate_financebench.py`, the judge LLM call at line 496 accesses `judge_response.choices[0].message.content` without checking:
- Whether `choices` is non-empty (can be `[]` on API error or rate-limiting → `IndexError`)
- Whether `choices[0].message` is non-None (Gemini returns `None` on `PROHIBITED_CONTENT` with HTTP 200 → `AttributeError`)

This fix adds the comprehensive guard:
```python
if not judge_response.choices or judge_response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```
The `ValueError` is caught by the outer `except Exception` block, which already falls back to string matching — so behavior is unchanged for the normal case.

Static analysis via [pact](https://github.com/qizwiz/pact) (Z3 Fixedpoint datalog, `llm_response_unguarded` rule); post-fix scan returns 0 violations.