### PR TITLE
fix: cap DashScope OpenAI-compat embedding batches

### DIFF
--- a/packages/leann-core/src/leann/embedding_compute.py
+++ b/packages/leann-core/src/leann/embedding_compute.py
@@ -816,6 +816,17 @@ def compute_embeddings_openai(
             max_batch_size,
         )
 
+    # Alibaba Cloud DashScope's OpenAI-compatible endpoint hard-limits embedding batches
+    # to 10 inputs per request (e.g. text-embedding-v4). Exceeding this returns HTTP 400:
+    #   "InternalError.Algo.InvalidParameter: Value error, batch size is invalid,
+    #    it should not be larger than 10.: input.contents"
+    if "dashscope" in (resolved_base_url or ""):
+        max_batch_size = min(max_batch_size, 10)
+        logger.info(
+            "Detected DashScope OpenAI-compatible base_url; capping embedding batch_size to %d.",
+            max_batch_size,
+        )
+
     # if avg len is less than 1000, use the max batch size
 
     try:

--- a/tests/test_embedding_prompt_template.py
+++ b/tests/test_embedding_prompt_template.py
@@ -222,6 +222,33 @@ class TestPromptTemplatePrepending:
         assert batch_sizes == [100, 100, 50]
         assert result.shape[0] == 250
 
+    def test_dashscope_openai_compat_caps_batch_size_to_10(
+        self, mock_openai_module, mock_openai_client
+    ):
+        texts = [f"Doc {i}" for i in range(25)]
+        provider_options = {
+            "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        }
+
+        mock_response = Mock()
+        mock_response.data = [Mock(embedding=[0.1, 0.2, 0.3]) for _ in range(25)]
+        mock_openai_client.embeddings.create.return_value = mock_response
+
+        result = compute_embeddings_openai(
+            texts=texts,
+            model_name="text-embedding-v4",
+            provider_options=provider_options,
+        )
+
+        # Should chunk into <=10 inputs per request (DashScope hard limit).
+        assert mock_openai_client.embeddings.create.call_count == 3
+        batch_sizes = [
+            len(call.kwargs["input"])
+            for call in mock_openai_client.embeddings.create.call_args_list
+        ]
+        assert batch_sizes == [10, 10, 5]
+        assert result.shape[0] == 25
+
     def test_prompt_template_with_special_characters(self, mock_openai_module, mock_openai_client):
         """Verify template with special characters is handled correctly.
 


### PR DESCRIPTION
## Summary

Alibaba Cloud DashScope's OpenAI-compatible endpoint
(`https://dashscope.aliyuncs.com/compatible-mode/v1`) hard-limits embedding
requests to **10 inputs per batch** (verified against `text-embedding-v4`).
Building an index with `leann build --embedding-mode openai
--embedding-api-base https://dashscope.aliyuncs.com/compatible-mode/v1
--embedding-model text-embedding-v4` fails immediately:

```
openai.BadRequestError: Error code: 400 - {
  'error': {
    'message': '<400> InternalError.Algo.InvalidParameter: Value error,
      batch size is invalid, it should not be larger than 10.:
      input.contents'
  }
}
```

This PR mirrors the existing Gemini-OpenAI-compat handling added in #214: when
the resolved `base_url` contains `"dashscope"`, cap `max_batch_size` to 10.

## Why a hard-coded URL check (same as Gemini)

`provider_options["batch_size"]` (#205) already lets Python API callers
override the batch size, but it is not exposed through the `leann build` CLI,
so command-line users hit this 400 with no escape. The DashScope cap is a
documented hard limit of the upstream API, so hard-coding it next to the
Gemini cap keeps the CLI path working out-of-the-box for the most common
Chinese cloud embedding provider, with no behavior change for other backends.

## Changes

- `packages/leann-core/src/leann/embedding_compute.py`: detect `dashscope`
  in `resolved_base_url` and cap `max_batch_size` to 10 with an INFO log,
  placed immediately after the Gemini check.
- `tests/test_embedding_prompt_template.py`: new
  `test_dashscope_openai_compat_caps_batch_size_to_10` mocks the OpenAI
  client, sends 25 texts, and asserts the three resulting batches are
  `[10, 10, 5]`.

## Verification

```
$ ruff format --check packages/leann-core/src/leann/embedding_compute.py \
                      tests/test_embedding_prompt_template.py
2 files already formatted

$ ruff check packages/leann-core/src/leann/embedding_compute.py \
             tests/test_embedding_prompt_template.py
All checks passed!

$ pytest tests/test_embedding_prompt_template.py -v
8 passed in 4.54s
```

End-to-end: with this patch applied locally, `leann build` against a
DashScope `text-embedding-v4` endpoint successfully indexed 3510 chunks
across 71 documents (350 batches of ≤10 inputs each) instead of failing on
the first request.

## Related work

- #214 — same pattern for Gemini.
- #205 — `provider_options["batch_size"]` (Python API only).
