### PR TITLE
fix(list): prune huge irrelevant dirs when scanning for indexes

### DIFF
--- a/packages/leann-core/src/leann/cli.py
+++ b/packages/leann-core/src/leann/cli.py
@@ -19,7 +19,7 @@ from tqdm import tqdm
 from .api import LeannBuilder, LeannChat, LeannSearcher
 from .embedding_server_manager import EmbeddingServerManager
 from .interactive_utils import create_cli_session
-from .registry import register_project_directory
+from .registry import register_project_directory, walk_index_meta_files
 from .settings import (
     resolve_anthropic_base_url,
     resolve_minimax_api_key,
@@ -956,7 +956,7 @@ Examples:
 
         # 2. Apps format: *.leann.meta.json files anywhere in the project
         cli_indexes_dir = project_path / ".leann" / "indexes"
-        for meta_file in project_path.rglob("*.leann.meta.json"):
+        for meta_file in walk_index_meta_files(project_path):
             if meta_file.is_file():
                 # Skip CLI-built indexes (which store meta under .leann/indexes/<name>/)
                 try:
@@ -1068,7 +1068,10 @@ Examples:
             seen_app_meta = set()
 
             # 2a) by file base
-            for meta_file in project_path.rglob(f"{index_name}.leann.meta.json"):
+            target_name = f"{index_name}.leann.meta.json"
+            for meta_file in walk_index_meta_files(project_path):
+                if meta_file.name != target_name:
+                    continue
                 if meta_file.is_file():
                     # Skip CLI-built indexes' meta under .leann/indexes
                     try:
@@ -1095,7 +1098,7 @@ Examples:
                     )
 
             # 2b) by parent directory name
-            for meta_file in project_path.rglob("*.leann.meta.json"):
+            for meta_file in walk_index_meta_files(project_path):
                 if meta_file.is_file() and meta_file.parent.name == index_name:
                     # Skip CLI-built indexes' meta under .leann/indexes
                     try:

--- a/packages/leann-core/src/leann/registry.py
+++ b/packages/leann-core/src/leann/registry.py
@@ -4,6 +4,8 @@ import importlib
 import importlib.metadata
 import json
 import logging
+import os
+from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Union
 
@@ -14,6 +16,45 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 BACKEND_REGISTRY: dict[str, "LeannBackendFactoryInterface"] = {}
+
+# Directories we never descend into during index discovery. These are caches,
+# dependencies, and build outputs that won't contain LEANN indexes and that
+# dominate walk latency under $HOME (especially macOS Library/). Keep this in
+# sync across cli.py callsites that scan for *.leann.meta.json files.
+INDEX_SCAN_SKIP_DIRS: frozenset[str] = frozenset(
+    {
+        ".git",
+        ".cache",
+        ".venv",
+        "venv",
+        "node_modules",
+        "__pycache__",
+        ".tox",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".pytest_cache",
+        "Library",
+        "target",
+        "dist",
+        "build",
+        ".next",
+        ".nuxt",
+        ".gradle",
+    }
+)
+
+
+def walk_index_meta_files(root: Path) -> Iterator[Path]:
+    """Yield *.leann.meta.json files under root, pruning huge irrelevant dirs.
+
+    Faster than Path.rglob('*.leann.meta.json') on large home directories where
+    Library/, node_modules/, .venv/, .git/, etc. would otherwise dominate the walk.
+    """
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in INDEX_SCAN_SKIP_DIRS]
+        for fname in filenames:
+            if fname.endswith(".leann.meta.json"):
+                yield Path(dirpath) / fname
 
 
 def register_backend(name: str):
@@ -64,9 +105,9 @@ def register_project_directory(project_dir: Optional[Union[str, Path]] = None):
         project_dir = Path(project_dir)
 
     # Only register directories that have some kind of LEANN content.
-    # Check CLI-format first to avoid an expensive rglob on large directories.
+    # Check CLI-format first to avoid an expensive walk on large directories.
     has_cli_indexes = (project_dir / ".leann" / "indexes").exists()
-    if not has_cli_indexes and not any(project_dir.rglob("*.leann.meta.json")):
+    if not has_cli_indexes and not any(walk_index_meta_files(project_dir)):
         # Don't register if there are no LEANN indexes
         return
 


### PR DESCRIPTION
Closes #122.

Four callsites use `Path.rglob("*.leann.meta.json")` with no pruning (cli.py:959/1071/1098, registry.py:69). In `\$HOME` that ends up walking `Library/`, `node_modules/`, `.git/`, etc., which I think is why `leann list` hangs for the reporter on #122. Replaced them with a walker that skips a small hardcoded set of well-known huge dirs (`INDEX_SCAN_SKIP_DIRS` in registry.py).

if indexes are put in one of those dirs,the constant is the only thing to change. 