### PR TITLE
Add optional build-time BM25 snapshots

### DIFF
--- a/packages/leann-core/src/leann/api.py
+++ b/packages/leann-core/src/leann/api.py
@@ -11,6 +11,7 @@ import re
 import subprocess
 import time
 import warnings
+from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -277,7 +278,33 @@ class PassageManager:
         return self._total_count
 
 
-class BM25Scorer:
+class BM25Index(ABC):
+    """Minimal contract for a BM25-style sparse index over LEANN passages.
+
+    Concrete implementations today: `BM25Scorer` (in-memory, fit-on-search).
+    Planned: an FTS5-backed implementation that builds at index-build time
+    and queries memory-bounded. See the design issue for the broader plan.
+    """
+
+    @abstractmethod
+    def fit(self, documents: list[dict[str, Any]]) -> None:
+        """Build the index from a corpus.
+
+        `documents` is a list of `{"id": str, "text": str, ...}` entries. Extra
+        fields are ignored by BM25 implementations but preserved by the caller
+        for use elsewhere.
+        """
+
+    @abstractmethod
+    def search(self, query: str, top_k: int = 5) -> list["SearchResult"]:
+        """Return up to `top_k` SearchResult entries ranked by descending score.
+
+        Returned SearchResults have `id` and `score` populated; `text` and
+        `metadata` are filled in by `LeannSearcher` from the passage store.
+        """
+
+
+class BM25Scorer(BM25Index):
     def __init__(self, k1: float = 1.2, b: float = 0.75):
         self.k1 = k1
         self.b = b

--- a/packages/leann-core/src/leann/api.py
+++ b/packages/leann-core/src/leann/api.py
@@ -388,8 +388,10 @@ class LeannBuilder:
         dimensions: Optional[int] = None,
         embedding_mode: str = "sentence-transformers",
         embedding_options: Optional[dict[str, Any]] = None,
+        prebuild_bm25: bool = False,
         **backend_kwargs,
     ):
+        self.prebuild_bm25 = prebuild_bm25
         self.backend_name = backend_name
         # Normalize incompatible combinations early (for consistent metadata)
         if backend_name == "hnsw":
@@ -605,8 +607,28 @@ class LeannBuilder:
             is_recompute = self.backend_kwargs.get("is_recompute", True)
             meta_data["is_compact"] = is_compact
             meta_data["is_pruned"] = bool(is_recompute)
+
+        if self.prebuild_bm25:
+            self._build_bm25_snapshot(index_dir, index_name)
+            meta_data["bm25_snapshot"] = f"{index_name}.bm25.pkl"
+
         with open(leann_meta_path, "w", encoding="utf-8") as f:
             json.dump(meta_data, f, indent=2)
+
+    def _build_bm25_snapshot(self, index_dir: Path, index_name: str) -> None:
+        """Fit BM25Scorer on self.chunks and pickle alongside the index.
+
+        Lets LeannSearcher._init_bm25 load the fitted scorer on first BM25 query
+        instead of re-fitting against the passage JSONL — which scans every
+        passage and builds the full TF table in RAM, dominating first-search
+        latency on larger corpora.
+        """
+        bm25_path = index_dir / f"{index_name}.bm25.pkl"
+        scorer = BM25Scorer()
+        scorer.fit(self.chunks)
+        with open(bm25_path, "wb") as f:
+            pickle.dump(scorer, f, protocol=pickle.HIGHEST_PROTOCOL)
+        logger.info(f"Wrote BM25 snapshot to {bm25_path}")
 
     def build_index_from_arrays(self, index_path: str, ids: list, embeddings: np.ndarray):
         """Build an index from pre-computed embedding arrays.
@@ -1409,9 +1431,24 @@ class LeannSearcher:
         return enriched_results
 
     def _init_bm25(self) -> None:
-        """Initialize BM25 scorer"""
+        """Initialize BM25 scorer, preferring a build-time snapshot when present."""
+        snapshot_name = self.meta_data.get("bm25_snapshot")
+        if snapshot_name:
+            snapshot_path = Path(self.meta_path_str).parent / snapshot_name
+            if snapshot_path.exists():
+                try:
+                    with open(snapshot_path, "rb") as f:
+                        self.bm25_scorer = pickle.load(f)
+                    logger.info(f"Loaded BM25 snapshot from {snapshot_path}")
+                    return
+                except Exception as exc:
+                    logger.warning(
+                        f"Failed to load BM25 snapshot at {snapshot_path}, "
+                        f"falling back to fit-on-search: {exc}"
+                    )
+
+        # No snapshot (older indexes) or snapshot load failed: fit on the fly.
         self.bm25_scorer = BM25Scorer()
-        # Load all the files directly
         passages = []
         for passage_file in self.passage_manager.passage_files.values():
             with open(passage_file, encoding="utf-8") as f:


### PR DESCRIPTION
## Summary

This adds an optional build-time BM25 snapshot so indexes can avoid fitting BM25 on the first keyword or hybrid query.

## What changed

- Added `LeannBuilder(prebuild_bm25=True)`.
- When enabled, build writes a BM25 snapshot next to the LEANN index and records it in `meta.json`.
- Search loads the snapshot when present, and falls back to the existing fit-on-search path for older indexes.
- Defaults remain unchanged, so existing callers and existing indexes keep working as before.

This is an incremental step toward making keyword retrieval persistent instead of rebuilding sparse state at query time.
