### PR TITLE
fix(mcp): resolve WinError 2 when leann CLI is not on PATH

### DIFF
--- a/packages/leann-core/src/leann/__main__.py
+++ b/packages/leann-core/src/leann/__main__.py
@@ -1,0 +1,3 @@
+from leann.cli import main
+
+main()

--- a/packages/leann-core/src/leann/cli.py
+++ b/packages/leann-core/src/leann/cli.py
@@ -53,9 +53,15 @@ def suppress_cpp_output(suppress: bool = True):
         yield
         return
 
-    # 1. Duplicate the original OS file descriptors
-    saved_stdout_fd = os.dup(1)
-    saved_stderr_fd = os.dup(2)
+    # 1. Duplicate the original OS file descriptors.
+    #    May fail in no-console environments (e.g. pythonw, Windows GUI apps)
+    #    where fd 1/2 are not valid — in that case, skip suppression.
+    try:
+        saved_stdout_fd = os.dup(1)
+        saved_stderr_fd = os.dup(2)
+    except OSError:
+        yield
+        return
 
     # 2. Build Python file objects that write to the saved (real) fds.
     #    closefd=False so closing these wrappers won't close the duped fds.
@@ -2653,12 +2659,16 @@ Examples:
                 print(f"Error: --metadata-filters is not valid JSON: {e}")
                 return
 
+        saved_fd = None
         if json_mode:
             sys.stdout.flush()
-            saved_fd = os.dup(1)
-            devnull = os.open(os.devnull, os.O_WRONLY)
-            os.dup2(devnull, 1)
-            os.close(devnull)
+            try:
+                saved_fd = os.dup(1)
+                devnull = os.open(os.devnull, os.O_WRONLY)
+                os.dup2(devnull, 1)
+                os.close(devnull)
+            except OSError:
+                saved_fd = None
 
         try:
             searcher = LeannSearcher(
@@ -2679,7 +2689,7 @@ Examples:
                 metadata_filters=metadata_filters,
             )
         finally:
-            if json_mode:
+            if saved_fd is not None:
                 sys.stdout.flush()
                 os.dup2(saved_fd, 1)
                 os.close(saved_fd)

--- a/packages/leann-core/src/leann/mcp.py
+++ b/packages/leann-core/src/leann/mcp.py
@@ -1,8 +1,21 @@
 #!/usr/bin/env python3
 
+import argparse
 import json
 import subprocess
 import sys
+
+_base_dir: str | None = None
+
+
+def _leann_cmd() -> list[str]:
+    """Build the base command for invoking ``leann`` CLI.
+
+    Using ``sys.executable -m leann`` guarantees we find the CLI even when
+    the ``leann`` console-script is not on PATH (common on Windows when
+    launched by mcp-proxy or other service wrappers).
+    """
+    return [sys.executable, "-m", "leann"]
 
 
 def handle_request(request):
@@ -100,7 +113,7 @@ def handle_request(request):
                     }
 
                 cmd = [
-                    "leann",
+                    *_leann_cmd(),
                     "search",
                     args["index_name"],
                     args["query"],
@@ -111,10 +124,15 @@ def handle_request(request):
                 ]
                 if args.get("show_metadata", False):
                     cmd.append("--show-metadata")
-                result = subprocess.run(cmd, capture_output=True, text=True)
+                result = subprocess.run(
+                    cmd, capture_output=True, text=True, cwd=_base_dir,
+                )
 
             elif tool_name == "leann_list":
-                result = subprocess.run(["leann", "list"], capture_output=True, text=True)
+                result = subprocess.run(
+                    [*_leann_cmd(), "list"],
+                    capture_output=True, text=True, cwd=_base_dir,
+                )
 
             return {
                 "jsonrpc": "2.0",
@@ -140,6 +158,17 @@ def handle_request(request):
 
 
 def main():
+    global _base_dir
+
+    parser = argparse.ArgumentParser(description="LEANN MCP server (stdio)")
+    parser.add_argument(
+        "--base-dir",
+        help="Base directory where LEANN indexes are located. "
+        "The leann CLI will run with this as its working directory.",
+    )
+    cli_args = parser.parse_args()
+    _base_dir = cli_args.base_dir
+
     for line in sys.stdin:
         try:
             request = json.loads(line.strip())

--- a/packages/leann-core/src/leann/mcp.py
+++ b/packages/leann-core/src/leann/mcp.py
@@ -125,13 +125,18 @@ def handle_request(request):
                 if args.get("show_metadata", False):
                     cmd.append("--show-metadata")
                 result = subprocess.run(
-                    cmd, capture_output=True, text=True, cwd=_base_dir,
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    cwd=_base_dir,
                 )
 
             elif tool_name == "leann_list":
                 result = subprocess.run(
                     [*_leann_cmd(), "list"],
-                    capture_output=True, text=True, cwd=_base_dir,
+                    capture_output=True,
+                    text=True,
+                    cwd=_base_dir,
                 )
 
             return {


### PR DESCRIPTION
## Summary

Fixes #320.

On Windows, when `leann_mcp.exe` is launched by `mcp-proxy`, the `leann` console-script may not be on the subprocess's PATH, causing `subprocess.run(["leann", ...])` to fail with `[WinError 2] The system cannot find the file specified`.

- **`mcp.py`**: Replace `["leann", ...]` with `[sys.executable, "-m", "leann", ...]` to invoke the CLI regardless of PATH. Add `--base-dir` argument support so the subprocess runs with the correct working directory for index resolution.
- **`__main__.py`**: New file enabling `python -m leann` invocation.
- **`cli.py`**: Guard `os.dup`/`os.dup2` calls in `suppress_cpp_output` and `search_documents` json_mode with `try/except OSError` for edge cases where fd 1/2 are not valid (e.g. no-console Windows GUI apps).

## Usage

After this fix, `mcp-proxy` users on Windows can run:
```
mcp-proxy.exe --host 0.0.0.0 --port 9090 -- leann_mcp.exe --base-dir "C:\TOD"
```
and the `--base-dir` will be correctly forwarded as the working directory for all `leann` CLI subprocess calls.

## Test plan

- [x] Verified `_leann_cmd()` returns `[sys.executable, "-m", "leann"]`
- [x] Verified `handle_request` works correctly for initialize, tools/list, and search validation
- [x] Verified `--base-dir` argument parsing
- [x] Verified `suppress_cpp_output` try/except guard works in normal and edge cases
- [x] Syntax check and ruff lint pass on all changed files
- [x] Windows user (@CodeRue) confirms the fix resolves the WinError 2