### PR TITLE
ci: run pre-commit with frozen uv lockfile

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run pre-commit with only lint group (no project deps)
         run: |
-          uv run --only-group lint pre-commit run --all-files --show-diff-on-failure
+          uv run --frozen --only-group lint pre-commit run --all-files --show-diff-on-failure
 
   type-check:
     name: Type Check with ty


### PR DESCRIPTION
- Run pre-commit through `uv run --frozen` so CI uses the committed lockfile instead of updating it.
- Keeps the fix to a one-line workflow change and avoids committing generated uv.lock metadata churn.