### PR TITLE
feat: add benchmark artifact tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ data/*
 !data/.gitattributes
 *.qdstrm
 benchmark_results/
+benchmark-results/
 results/
 frac_*.png
 final_in_*.png

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,135 +1,108 @@
-# 🧪 LEANN Benchmarks & Testing
+# LEANN Benchmarks
 
-This directory contains performance benchmarks and comprehensive tests for the LEANN system, including backend comparisons and sanity checks across different configurations.
+This directory contains benchmark scripts and data-dependent evaluation suites for LEANN. The
+canonical benchmark inventory now lives in [docs/benchmarks.md](../docs/benchmarks.md).
 
-## 📁 Test Files
+## Quick Starts
 
-### `diskann_vs_hnsw_speed_comparison.py`
-Performance comparison between DiskANN and HNSW backends:
-- ✅ **Search latency** comparison with both backends using recompute
-- ✅ **Index size** and **build time** measurements
-- ✅ **Score validity** testing (ensures no -inf scores)
-- ✅ **Configurable dataset sizes** for different scales
+Run a small backend comparison:
 
 ```bash
-# Quick comparison with 500 docs, 10 queries
-python benchmarks/diskann_vs_hnsw_speed_comparison.py
-
-# Large-scale comparison with 2000 docs, 20 queries
-python benchmarks/diskann_vs_hnsw_speed_comparison.py 2000 20
+uv run python benchmarks/diskann_vs_hnsw_speed_comparison.py
 ```
 
-### `test_distance_functions.py`
-Tests all supported distance functions across DiskANN backend:
-- ✅ **MIPS** (Maximum Inner Product Search)
-- ✅ **L2** (Euclidean Distance)
-- ✅ **Cosine** (Cosine Similarity)
+Compare LEANN storage usage against a FAISS baseline:
 
 ```bash
-uv run python tests/sanity_checks/test_distance_functions.py
+uv run python benchmarks/compare_faiss_vs_leann.py
 ```
 
-### `test_l2_verification.py`
-Specifically verifies that L2 distance is correctly implemented by:
-- Building indices with L2 vs Cosine metrics
-- Comparing search results and score ranges
-- Validating that different metrics produce expected score patterns
+Run the main retrieval evaluation driver:
 
 ```bash
-uv run python tests/sanity_checks/test_l2_verification.py
+uv run benchmarks/run_evaluation.py
 ```
 
-### `test_sanity_check.py`
-Comprehensive end-to-end verification including:
-- Distance function testing
-- Embedding model compatibility
-- Search result correctness validation
-- Backend integration testing
+This command treats an incomplete `benchmarks/data/` tree, including a README-only checkout or an
+`indices/` tree without any `.index` artifact, as missing benchmark data and downloads the public
+data pack. The repository-provided prebuilt indexes are large; check local disk capacity before
+relying on the automatic download path.
+
+For larger retrieval runs after data has been downloaded:
 
 ```bash
-uv run python tests/sanity_checks/test_sanity_check.py
+uv run benchmarks/run_evaluation.py benchmarks/data/indices/rpj_wiki/rpj_wiki \
+  --dataset rpj_wiki \
+  --data-source LEANN-RAG/leann-rag-evaluation-data \
+  --data-revision 2026-06-02-download \
+  --num-queries 2000 \
+  --top-k 3 \
+  --complexity 120 \
+  --format markdown \
+  --json-output benchmark-results/retrieval-rpj-wiki.json \
+  --markdown-output benchmark-results/retrieval-rpj-wiki.md
 ```
 
-## 🎯 What These Tests Verify
+Retrieval evaluation is search-only by default. Use `--run-llm` only when generation should be
+included as opt-in metadata outside retrieval latency. Retrieval artifacts include per-query result
+IDs, golden IDs, and duplicate-text counters so reviewers can audit text-overlap recall when passage
+ID schemes differ across indexes. CLI-generated artifacts also record SHA256 hashes for the query
+and ground-truth files plus shell-quoted script command arguments.
 
-### ✅ Distance Function Support
-- All three distance metrics (MIPS, L2, Cosine) work correctly
-- Score ranges are appropriate for each metric type
-- Different metrics can produce different rankings (as expected)
+Retrieval and query-log artifacts share the same timing-statistics helper. p95 is the lower
+nearest-rank observed sample from sorted timings, so it is deterministic and comparable across
+reviewable benchmark reports. The standalone BM25 and DiskANN baseline scripts use the same
+observed-sample percentile helpers for their latency report fields.
 
-### ✅ Backend Integration
-- DiskANN backend properly initializes and builds indices
-- Graph construction completes without errors
-- Search operations return valid results
+Run one retrieval manifest across multiple prebuilt backend indexes:
 
-### ✅ Embedding Pipeline
-- Real-time embedding computation works
-- Multiple embedding models are supported
-- ZMQ server communication functions correctly
-
-### ✅ End-to-End Functionality
-- Index building → searching → result retrieval pipeline
-- Metadata preservation through the entire flow
-- Error handling and graceful degradation
-
-## 🔍 Expected Output
-
-When all tests pass, you should see:
-
-```
-📊 测试结果总结:
-  mips      : ✅ 通过
-  l2        : ✅ 通过
-  cosine    : ✅ 通过
-
-🎉 测试完成!
-```
-
-## 🐛 Troubleshooting
-
-### Common Issues
-
-**Import Errors**: Ensure you're running from the project root:
 ```bash
-cd /path/to/leann
-uv run python tests/sanity_checks/test_distance_functions.py
+uv run python benchmarks/compare_retrieval_backends.py benchmark-results/retrieval-comparison.json \
+  --format markdown \
+  --json-output benchmark-results/retrieval-comparison-summary.json \
+  --markdown-output benchmark-results/retrieval-comparison-summary.md
 ```
 
-**Memory Issues**: Reduce graph complexity for resource-constrained systems:
-```python
-builder = LeannBuilder(
-    backend_name="diskann",
-    graph_degree=8,  # Reduced from 16
-    complexity=16    # Reduced from 32
-)
-```
+The comparison manifest keeps dataset, query file, ground truth, `top_k`, complexity, and batch
+size identical across runs. The combined JSON/Markdown artifacts report per-run backend,
+passage-ID scheme, embedding model/mode, recall@k, hit rate@k, latency, storage bytes, query file
+hash, ground-truth file hash, shell-quoted script command arguments, missing result-ID counts, and
+duplicate result/golden text counters.
+See [docs/benchmarks.md](../docs/benchmarks.md) for the manifest fields and a complete example.
 
-**ZMQ Port Conflicts**: The tests use different ports to avoid conflicts, but you may need to kill existing processes:
+Summarize query logs with optional ground truth and storage accounting:
+
 ```bash
-pkill -f "embedding_server"
+uv run python benchmarks/summarize_query_log.py queries.jsonl \
+  --ground-truth ground_truth.json \
+  --index-path .leann/indexes/my-index/documents.leann \
+  --data-source my-dataset \
+  --data-revision 2026-06-02-download \
+  --format markdown \
+  --json-output benchmark-results/my-index-summary.json \
+  --markdown-output benchmark-results/my-index-summary.md
 ```
 
-## 📊 Performance Expectations
+`--format` controls stdout. Use `--json-output` and `--markdown-output` to write durable review
+artifacts in the same run. Query-log summaries include latency mean/median/p95/min/max when
+available plus counters for records with missing result IDs, total missing result IDs, missing
+latency, missing search mode, missing backend metadata, and shell-quoted script command arguments.
 
-### Typical Timing (3 documents, consumer hardware):
-- **Index Building**: 2-5 seconds per distance function
-- **Search Query**: 50-200ms
-- **Recompute Mode**: 5-15 seconds (higher accuracy)
+The `benchmark-results/` directory is ignored by git and is the default scratch location for local
+summary artifacts. Commit only curated reports with full dataset, hardware, and command context.
 
-### Memory Usage:
-- **Index Storage**: ~1-2 MB per distance function
-- **Runtime Memory**: ~500MB (including model loading)
+## Suites
 
-## 🔗 Integration with CI/CD
+- `bm25_diskann_baselines/`: Natural Questions BM25 and DiskANN search-only baselines that require
+  externally synced artifacts, report latency with the shared observed-sample percentile helpers,
+  and can write JSON reports with query hashes, timing scope, recursive storage bytes, settings,
+  command arguments, and environment provenance.
+- `contextbench/`: trace-driven code-assistant benchmark tooling.
+- `enron_emails/`: retrieval and generation evaluation on the Enron email corpus.
+- `financebench/`: financial document question-answering benchmark.
+- `laion/`: multimodal image/text retrieval benchmark.
+- `update/`: update-latency and sequential-vs-offline update strategy benchmarks.
 
-These tests are designed to be run in automated environments:
-
-```yaml
-# GitHub Actions example
-- name: Run Sanity Checks
-  run: |
-    uv run python tests/sanity_checks/test_distance_functions.py
-    uv run python tests/sanity_checks/test_l2_verification.py
-```
-
-The tests are deterministic and should produce consistent results across different platforms.
+Benchmark result files committed under subdirectories are reference outputs from their documented
+settings and hardware. Do not treat them as automatically refreshed results for the current branch
+unless the relevant command has been rerun.

--- a/benchmarks/artifact_formatting.py
+++ b/benchmarks/artifact_formatting.py
@@ -1,0 +1,10 @@
+"""Markdown formatting helpers for benchmark artifacts."""
+
+from __future__ import annotations
+
+
+def command_markdown_lines(command: str | None) -> list[str]:
+    """Return Markdown lines for a benchmark script command."""
+    if not command:
+        return ["- Command: unavailable"]
+    return ["- Command:", "", "```bash", command, "```"]

--- a/benchmarks/bm25_diskann_baselines/README.md
+++ b/benchmarks/bm25_diskann_baselines/README.md
@@ -6,18 +6,27 @@ aws s3 sync s3://powerrag-diskann-rpj-wiki-20250824-224037-194d640c/diskann_rpj_
 ```
 
 - Dataset: `benchmarks/data/queries/nq_open.jsonl` (Natural Questions)
-- Machine-specific; results measured locally with the current repo.
+- Machine-specific; the sample results below are historical local output and should be regenerated
+  for current hardware, dependencies, and code.
+- Current scripts compute p50 as the median sample summary and p90/p95/p99 as lower nearest-rank
+  observed samples, matching the shared LEANN benchmark timing helpers.
 
 DiskANN (NQ queries, search-only)
-- Command: `uv run --script benchmarks/bm25_diskann_baselines/run_diskann.py`
+- Command from the repository root: `uv run --script benchmarks/bm25_diskann_baselines/run_diskann.py --report benchmark-results/diskann-baseline.json`
 - Settings: `recompute_embeddings=False`, embeddings precomputed (excluded from timing), batching off, caching off (`cache_mechanism=2`, `num_nodes_to_cache=0`)
 - Result: avg 0.011093 s/query, QPS 90.15 (p50 0.010731 s, p95 0.015000 s)
 
 BM25
-- Command: `uv run --script benchmarks/bm25_diskann_baselines/run_bm25.py`
+- Command from the repository root: `uv run --script benchmarks/bm25_diskann_baselines/run_bm25.py --report benchmark-results/bm25-baseline.json`
 - Settings: `k=10`, `k1=0.9`, `b=0.4`, queries=100
 - Result: avg 0.028589 s/query, QPS 34.97 (p50 0.026060 s, p90 0.043695 s, p95 0.053260 s, p99 0.055257 s)
 
 Notes
 - DiskANN measures search-only latency on real NQ queries (embeddings computed beforehand and excluded from timing).
 - Use `benchmarks/bm25_diskann_baselines/run_diskann.py` for DiskANN; `benchmarks/bm25_diskann_baselines/run_bm25.py` for BM25.
+- Pass `--data-source` and `--data-revision` when generating reports for PR review. JSON reports
+  include schema version, benchmark name, query-file SHA256, shell-quoted script command arguments,
+  baseline settings, timing scope, recursive index-directory storage bytes/file count, latency
+  summaries, and local environment metadata. BM25 reports use `timing_scope=search_with_doc_fetch`
+  when `--fetch-docs` is enabled; otherwise both BM25 and DiskANN report
+  `timing_scope=search_only`.

--- a/benchmarks/bm25_diskann_baselines/run_bm25.py
+++ b/benchmarks/bm25_diskann_baselines/run_bm25.py
@@ -17,7 +17,16 @@ import json
 import os
 import sys
 import time
-from statistics import mean
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from benchmarks.metrics import observed_percentile, timing_stats
+from benchmarks.provenance import benchmark_command, environment_metadata, file_sha256
+from benchmarks.storage import directory_storage
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def load_queries(path: str, limit: int | None) -> list[str]:
@@ -51,28 +60,113 @@ def load_queries(path: str, limit: int | None) -> list[str]:
     return queries
 
 
-def percentile(values: list[float], p: float) -> float:
-    if not values:
-        return 0.0
-    s = sorted(values)
-    k = (len(s) - 1) * (p / 100.0)
-    f = int(k)
-    c = min(f + 1, len(s) - 1)
-    if f == c:
-        return s[f]
-    return s[f] + (s[c] - s[f]) * (k - f)
+def latency_report(
+    latencies: list[float],
+    *,
+    total_searches: int,
+    total_time: float,
+) -> dict[str, float | int]:
+    stats = timing_stats(latencies)
+    return {
+        "queries": total_searches,
+        "avg_s": stats["mean"],
+        "p50_s": stats["median"],
+        "p90_s": observed_percentile(latencies, 90),
+        "p95_s": stats["p95"],
+        "p99_s": observed_percentile(latencies, 99),
+        "min_s": stats["min"],
+        "max_s": stats["max"],
+        "total_time_s": total_time,
+        "qps": total_searches / total_time if total_time > 0 else 0.0,
+    }
 
 
-def main():
+def benchmark_report(
+    *,
+    latency: dict[str, float | int],
+    queries_file: str | Path,
+    index_dir: str | Path,
+    k: int,
+    k1: float,
+    b: float,
+    warmup: int,
+    fetch_docs: bool,
+    requested_query_count: int,
+    data_source: str | None,
+    data_revision: str | None,
+    command: str | None,
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "benchmark": "bm25_baseline_latency",
+        "data_source": data_source,
+        "data_revision": data_revision,
+        "command": command,
+        "queries_file": str(queries_file),
+        "queries_sha256": file_sha256(queries_file),
+        "index_dir": str(Path(index_dir).resolve()),
+        "storage": directory_storage(index_dir),
+        "query_count": latency["queries"],
+        "requested_query_count": requested_query_count,
+        "timing_scope": "search_with_doc_fetch" if fetch_docs else "search_only",
+        "settings": {
+            "k": k,
+            "k1": k1,
+            "b": b,
+            "warmup": warmup,
+            "fetch_docs": fetch_docs,
+        },
+        "latency_s": {
+            "mean": latency["avg_s"],
+            "median": latency["p50_s"],
+            "p90": latency["p90_s"],
+            "p95": latency["p95_s"],
+            "p99": latency["p99_s"],
+            "min": latency["min_s"],
+            "max": latency["max_s"],
+            "total": latency["total_time_s"],
+            "qps": latency["qps"],
+        },
+        "environment": environment_metadata(),
+    }
+
+
+def write_json_report(path: str | Path, payload: dict[str, object]) -> None:
+    report_path = Path(path)
+    if report_path.exists() and report_path.is_dir():
+        raise IsADirectoryError(f"report path is a directory: {report_path}")
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _validate_report_path(
+    parser: argparse.ArgumentParser,
+    *,
+    report_path: str | None,
+    queries_path: str | Path,
+    index_dir: str | Path,
+) -> None:
+    if not report_path:
+        return
+    resolved_report = Path(report_path).resolve()
+    if resolved_report == Path(queries_path).resolve():
+        parser.error("report path must not overwrite the queries file")
+    resolved_index_dir = Path(index_dir).resolve()
+    if resolved_report == resolved_index_dir or resolved_index_dir in resolved_report.parents:
+        parser.error("report path must not be inside the index directory")
+
+
+def main(argv: list[str] | None = None):
+    command = benchmark_command(__file__, argv)
     ap = argparse.ArgumentParser(description="Standalone BM25 latency benchmark (Pyserini)")
     ap.add_argument(
         "--bm25-index",
-        default="benchmarks/data/indices/bm25_index",
+        default=str(REPO_ROOT / "benchmarks/data/indices/bm25_index"),
         help="Path to Pyserini Lucene index directory",
     )
     ap.add_argument(
         "--queries",
-        default="benchmarks/data/queries/nq_open.jsonl",
+        default=str(REPO_ROOT / "benchmarks/data/queries/nq_open.jsonl"),
         help="Path to queries file (JSONL with 'query'/'text' or plain txt one-per-line)",
     )
     ap.add_argument("--k", type=int, default=10, help="Top-k to retrieve (default: 10)")
@@ -85,8 +179,29 @@ def main():
     ap.add_argument(
         "--fetch-docs", action="store_true", help="Also fetch doc contents (slower; default: off)"
     )
+    ap.add_argument(
+        "--data-source",
+        help="Dataset/source identifier recorded in benchmark report artifacts.",
+    )
+    ap.add_argument(
+        "--data-revision",
+        help="Dataset revision, snapshot, or download date recorded in benchmark reports.",
+    )
     ap.add_argument("--report", type=str, default=None, help="Optional JSON report path")
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
+
+    if args.k <= 0:
+        ap.error("--k must be greater than 0")
+    if args.limit <= 0:
+        ap.error("--limit must be greater than 0")
+    if args.warmup < 0:
+        ap.error("--warmup must be greater than or equal to 0")
+    _validate_report_path(
+        ap,
+        report_path=args.report,
+        queries_path=args.queries,
+        index_dir=args.bm25_index,
+    )
 
     try:
         from pyserini.search.lucene import LuceneSearcher
@@ -123,9 +238,6 @@ def main():
     for i, q in enumerate(queries):
         t1 = time.time()
         hits = searcher.search(q, k=args.k)
-        t2 = time.time()
-        latencies.append(t2 - t1)
-        total_searches += 1
 
         if args.fetch_docs:
             # Optional doc fetch to include I/O time
@@ -134,6 +246,9 @@ def main():
                     _ = searcher.doc(h.docid)
                 except Exception:
                     pass
+        t2 = time.time()
+        latencies.append(t2 - t1)
+        total_searches += 1
 
         if (i + 1) % 50 == 0:
             print(f"Processed {i + 1}/{len(queries)} queries")
@@ -141,41 +256,35 @@ def main():
     t1 = time.time()
     total_time = t1 - t0
 
-    if latencies:
-        avg = mean(latencies)
-        p50 = percentile(latencies, 50)
-        p90 = percentile(latencies, 90)
-        p95 = percentile(latencies, 95)
-        p99 = percentile(latencies, 99)
-        qps = total_searches / total_time if total_time > 0 else 0.0
-    else:
-        avg = p50 = p90 = p95 = p99 = qps = 0.0
+    latency = latency_report(latencies, total_searches=total_searches, total_time=total_time)
 
     print("BM25 Latency Report")
     print(f"  queries: {total_searches}")
     print(f"  k: {args.k}, k1: {args.k1}, b: {args.b}")
-    print(f"  avg per query: {avg:.6f} s")
-    print(f"  p50/p90/p95/p99: {p50:.6f}/{p90:.6f}/{p95:.6f}/{p99:.6f} s")
-    print(f"  total time: {total_time:.3f} s, qps: {qps:.2f}")
+    print(f"  avg per query: {latency['avg_s']:.6f} s")
+    print(
+        "  p50/p90/p95/p99: "
+        f"{latency['p50_s']:.6f}/{latency['p90_s']:.6f}/"
+        f"{latency['p95_s']:.6f}/{latency['p99_s']:.6f} s"
+    )
+    print(f"  total time: {total_time:.3f} s, qps: {latency['qps']:.2f}")
 
     if args.report:
-        payload = {
-            "queries": total_searches,
-            "k": args.k,
-            "k1": args.k1,
-            "b": args.b,
-            "avg_s": avg,
-            "p50_s": p50,
-            "p90_s": p90,
-            "p95_s": p95,
-            "p99_s": p99,
-            "total_time_s": total_time,
-            "qps": qps,
-            "index_dir": os.path.abspath(args.bm25_index),
-            "fetch_docs": bool(args.fetch_docs),
-        }
-        with open(args.report, "w", encoding="utf-8") as f:
-            json.dump(payload, f, indent=2)
+        payload = benchmark_report(
+            latency=latency,
+            queries_file=args.queries,
+            index_dir=args.bm25_index,
+            k=args.k,
+            k1=args.k1,
+            b=args.b,
+            warmup=args.warmup,
+            fetch_docs=bool(args.fetch_docs),
+            requested_query_count=args.limit,
+            data_source=args.data_source,
+            data_revision=args.data_revision,
+            command=command,
+        )
+        write_json_report(args.report, payload)
         print(f"Saved report to {args.report}")
 
 

--- a/benchmarks/bm25_diskann_baselines/run_bm25.py
+++ b/benchmarks/bm25_diskann_baselines/run_bm25.py
@@ -18,6 +18,7 @@ import os
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
@@ -95,7 +96,7 @@ def benchmark_report(
     data_source: str | None,
     data_revision: str | None,
     command: str | None,
-) -> dict[str, object]:
+) -> dict[str, Any]:
     return {
         "schema_version": 1,
         "benchmark": "bm25_baseline_latency",
@@ -131,7 +132,7 @@ def benchmark_report(
     }
 
 
-def write_json_report(path: str | Path, payload: dict[str, object]) -> None:
+def write_json_report(path: str | Path, payload: dict[str, Any]) -> None:
     report_path = Path(path)
     if report_path.exists() and report_path.is_dir():
         raise IsADirectoryError(f"report path is a directory: {report_path}")

--- a/benchmarks/bm25_diskann_baselines/run_diskann.py
+++ b/benchmarks/bm25_diskann_baselines/run_diskann.py
@@ -6,10 +6,20 @@
 
 import argparse
 import json
+import sys
 import time
 from pathlib import Path
 
 import numpy as np
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from benchmarks.metrics import observed_percentile, timing_stats
+from benchmarks.provenance import benchmark_command, environment_metadata, file_sha256
+from benchmarks.storage import directory_storage
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def load_queries(path: Path, limit: int | None) -> list[str]:
@@ -18,22 +28,129 @@ def load_queries(path: Path, limit: int | None) -> list[str]:
         for line in f:
             obj = json.loads(line)
             out.append(obj["query"])
-            if limit and len(out) >= limit:
+            if limit is not None and len(out) >= limit:
                 break
     return out
 
 
-def main() -> None:
+def latency_report(times: list[float]) -> dict[str, float | int]:
+    stats = timing_stats(times)
+    return {
+        "queries": len(times),
+        "avg_s": stats["mean"],
+        "p50_s": stats["median"],
+        "p90_s": observed_percentile(times, 90),
+        "p95_s": stats["p95"],
+        "p99_s": observed_percentile(times, 99),
+        "min_s": stats["min"],
+        "max_s": stats["max"],
+        "total_time_s": sum(times),
+        "qps": 1.0 / stats["mean"] if stats["mean"] > 0 else 0.0,
+    }
+
+
+def benchmark_report(
+    *,
+    latency: dict[str, float | int],
+    queries_file: str | Path,
+    index_dir: str | Path,
+    index_prefix: str,
+    top_k: int,
+    complexity: int,
+    threads: int,
+    beam_width: int,
+    cache_mechanism: int,
+    num_nodes_to_cache: int,
+    requested_query_count: int,
+    data_source: str | None,
+    data_revision: str | None,
+    command: str | None,
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "benchmark": "diskann_baseline_latency",
+        "data_source": data_source,
+        "data_revision": data_revision,
+        "command": command,
+        "queries_file": str(queries_file),
+        "queries_sha256": file_sha256(queries_file),
+        "index_dir": str(Path(index_dir).resolve()),
+        "index_prefix": index_prefix,
+        "index_prefix_path": str(Path(index_dir).resolve() / index_prefix),
+        "storage": directory_storage(index_dir),
+        "query_count": latency["queries"],
+        "requested_query_count": requested_query_count,
+        "embedding_model": "facebook/contriever-msmarco",
+        "embedding_mode": "sentence-transformers",
+        "embedding_in_latency": False,
+        "timing_scope": "search_only",
+        "settings": {
+            "top_k": top_k,
+            "complexity": complexity,
+            "threads": threads,
+            "beam_width": beam_width,
+            "cache_mechanism": cache_mechanism,
+            "num_nodes_to_cache": num_nodes_to_cache,
+            "prune_ratio": 0.0,
+            "recompute_embeddings": False,
+            "batch_recompute": False,
+            "dedup_node_dis": False,
+        },
+        "latency_s": {
+            "mean": latency["avg_s"],
+            "median": latency["p50_s"],
+            "p90": latency["p90_s"],
+            "p95": latency["p95_s"],
+            "p99": latency["p99_s"],
+            "min": latency["min_s"],
+            "max": latency["max_s"],
+            "total": latency["total_time_s"],
+            "qps": latency["qps"],
+        },
+        "environment": environment_metadata(),
+    }
+
+
+def write_json_report(path: str | Path, payload: dict[str, object]) -> None:
+    report_path = Path(path)
+    if report_path.exists() and report_path.is_dir():
+        raise IsADirectoryError(f"report path is a directory: {report_path}")
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _validate_report_path(
+    parser: argparse.ArgumentParser,
+    *,
+    report_path: str | None,
+    queries_path: str | Path,
+    index_dir: str | Path,
+) -> None:
+    if not report_path:
+        return
+    resolved_report = Path(report_path).resolve()
+    if resolved_report == Path(queries_path).resolve():
+        parser.error("report path must not overwrite the queries file")
+    resolved_index_dir = Path(index_dir).resolve()
+    if resolved_report == resolved_index_dir or resolved_index_dir in resolved_report.parents:
+        parser.error("report path must not be inside the index directory")
+
+
+def main(argv: list[str] | None = None) -> None:
+    command = benchmark_command(__file__, argv)
     ap = argparse.ArgumentParser(
         description="DiskANN baseline on real NQ queries (search-only timing)"
     )
     ap.add_argument(
         "--index-dir",
-        default="benchmarks/data/indices/diskann_rpj_wiki",
+        default=str(REPO_ROOT / "benchmarks/data/indices/diskann_rpj_wiki"),
         help="Directory containing DiskANN files",
     )
     ap.add_argument("--index-prefix", default="ann")
-    ap.add_argument("--queries-file", default="benchmarks/data/queries/nq_open.jsonl")
+    ap.add_argument(
+        "--queries-file",
+        default=str(REPO_ROOT / "benchmarks/data/queries/nq_open.jsonl"),
+    )
     ap.add_argument("--num-queries", type=int, default=200)
     ap.add_argument("--top-k", type=int, default=10)
     ap.add_argument("--complexity", type=int, default=62)
@@ -41,7 +158,35 @@ def main() -> None:
     ap.add_argument("--beam-width", type=int, default=1)
     ap.add_argument("--cache-mechanism", type=int, default=2)
     ap.add_argument("--num-nodes-to-cache", type=int, default=0)
-    args = ap.parse_args()
+    ap.add_argument(
+        "--data-source",
+        help="Dataset/source identifier recorded in benchmark report artifacts.",
+    )
+    ap.add_argument(
+        "--data-revision",
+        help="Dataset revision, snapshot, or download date recorded in benchmark reports.",
+    )
+    ap.add_argument("--report", help="Optional JSON report path.")
+    args = ap.parse_args(argv)
+
+    if args.num_queries <= 0:
+        ap.error("--num-queries must be greater than 0")
+    if args.top_k <= 0:
+        ap.error("--top-k must be greater than 0")
+    if args.complexity <= 0:
+        ap.error("--complexity must be greater than 0")
+    if args.threads <= 0:
+        ap.error("--threads must be greater than 0")
+    if args.beam_width <= 0:
+        ap.error("--beam-width must be greater than 0")
+    if args.num_nodes_to_cache < 0:
+        ap.error("--num-nodes-to-cache must be greater than or equal to 0")
+    _validate_report_path(
+        ap,
+        report_path=args.report,
+        queries_path=args.queries_file,
+        index_dir=args.index_dir,
+    )
 
     index_dir = Path(args.index_dir).resolve()
     if not index_dir.is_dir():
@@ -105,19 +250,36 @@ def main() -> None:
         )
         times.append(time.time() - t0)
 
-    times_sorted = sorted(times)
-    avg = float(sum(times) / len(times))
-    p50 = times_sorted[len(times) // 2]
-    p95 = times_sorted[max(0, int(len(times) * 0.95) - 1)]
+    latency = latency_report(times)
 
     print("\nDiskANN (NQ, search-only) Report")
-    print(f"  queries: {len(times)}")
+    print(f"  queries: {latency['queries']}")
     print(
         f"  k: {args.top_k}, complexity: {args.complexity}, beam_width: {args.beam_width}, threads: {args.threads}"
     )
-    print(f"  avg per query: {avg:.6f} s")
-    print(f"  p50/p95: {p50:.6f}/{p95:.6f} s")
-    print(f"  QPS: {1.0 / avg:.2f}")
+    print(f"  avg per query: {latency['avg_s']:.6f} s")
+    print(f"  p50/p95: {latency['p50_s']:.6f}/{latency['p95_s']:.6f} s")
+    print(f"  QPS: {latency['qps']:.2f}")
+
+    if args.report:
+        payload = benchmark_report(
+            latency=latency,
+            queries_file=qpath,
+            index_dir=index_dir,
+            index_prefix=args.index_prefix,
+            top_k=args.top_k,
+            complexity=args.complexity,
+            threads=args.threads,
+            beam_width=args.beam_width,
+            cache_mechanism=args.cache_mechanism,
+            num_nodes_to_cache=args.num_nodes_to_cache,
+            requested_query_count=args.num_queries,
+            data_source=args.data_source,
+            data_revision=args.data_revision,
+            command=command,
+        )
+        write_json_report(args.report, payload)
+        print(f"Saved report to {args.report}")
 
 
 if __name__ == "__main__":

--- a/benchmarks/bm25_diskann_baselines/run_diskann.py
+++ b/benchmarks/bm25_diskann_baselines/run_diskann.py
@@ -9,6 +9,7 @@ import json
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
@@ -65,7 +66,7 @@ def benchmark_report(
     data_source: str | None,
     data_revision: str | None,
     command: str | None,
-) -> dict[str, object]:
+) -> dict[str, Any]:
     return {
         "schema_version": 1,
         "benchmark": "diskann_baseline_latency",
@@ -111,7 +112,7 @@ def benchmark_report(
     }
 
 
-def write_json_report(path: str | Path, payload: dict[str, object]) -> None:
+def write_json_report(path: str | Path, payload: dict[str, Any]) -> None:
     report_path = Path(path)
     if report_path.exists() and report_path.is_dir():
         raise IsADirectoryError(f"report path is a directory: {report_path}")

--- a/benchmarks/compare_retrieval_backends.py
+++ b/benchmarks/compare_retrieval_backends.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Run one retrieval benchmark manifest across multiple prebuilt LEANN indexes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from benchmarks import run_evaluation
+from benchmarks.artifact_formatting import command_markdown_lines
+from benchmarks.provenance import benchmark_command, environment_metadata, file_sha256
+
+
+def load_manifest(path: str | Path) -> dict[str, Any]:
+    manifest_path = Path(path)
+    with manifest_path.open(encoding="utf-8") as handle:
+        manifest = json.load(handle)
+    if not isinstance(manifest, dict):
+        raise ValueError("comparison manifest must be a JSON object")
+    return manifest
+
+
+def run_comparison(
+    manifest: dict[str, Any],
+    *,
+    manifest_dir: str | Path = ".",
+    command: str | None = None,
+) -> dict[str, Any]:
+    """Evaluate all manifest runs with identical retrieval settings."""
+    config = _comparison_config(manifest, Path(manifest_dir))
+    queries = run_evaluation.load_queries(config["queries_file"])
+    if not queries:
+        raise ValueError("queries file did not contain any queries")
+    queries_sha256 = file_sha256(config["queries_file"])
+    ground_truth_sha256 = file_sha256(config["ground_truth_file"])
+    with config["ground_truth_file"].open(encoding="utf-8") as handle:
+        golden_results_data = json.load(handle)
+
+    evaluations: list[dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
+    for run_config in config["runs"]:
+        searcher = run_evaluation.LeannSearcher(str(run_config["index_path"]))
+        summary = run_evaluation.run_retrieval_evaluation(
+            searcher,
+            queries,
+            golden_results_data,
+            index_path=str(run_config["index_path"]),
+            dataset_type=config["dataset"],
+            queries_file=config["queries_file"],
+            ground_truth_file=config["ground_truth_file"],
+            num_queries=config["num_queries"],
+            top_k=config["top_k"],
+            complexity=config["complexity"],
+            batch_size=config["batch_size"],
+            data_source=config["data_source"],
+            data_revision=config["data_revision"],
+            queries_sha256=queries_sha256,
+            ground_truth_sha256=ground_truth_sha256,
+        )
+        _validate_manifest_backend(run_config, summary)
+        summary["comparison_run_name"] = run_config["name"]
+        if run_config.get("backend"):
+            summary["manifest_backend"] = run_config["backend"]
+        evaluations.append(summary)
+        rows.append(_comparison_row(run_config, summary))
+
+    return {
+        "schema_version": 1,
+        "benchmark": "retrieval_backend_comparison",
+        "dataset": config["dataset"],
+        "data_source": config["data_source"],
+        "data_revision": config["data_revision"],
+        "command": command,
+        "queries_file": str(config["queries_file"]),
+        "queries_sha256": queries_sha256,
+        "ground_truth_file": str(config["ground_truth_file"]),
+        "ground_truth_sha256": ground_truth_sha256,
+        "requested_query_count": config["num_queries"],
+        "top_k": config["top_k"],
+        "complexity": config["complexity"],
+        "batch_size": config["batch_size"],
+        "run_count": len(rows),
+        "environment": environment_metadata(),
+        "runs": rows,
+        "evaluations": evaluations,
+    }
+
+
+def format_summary(summary: dict[str, Any], output_format: str) -> str:
+    if output_format == "json":
+        return json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    if output_format == "markdown":
+        return format_markdown(summary)
+    raise ValueError(f"unsupported output format: {output_format}")
+
+
+def format_markdown(summary: dict[str, Any]) -> str:
+    top_k = summary["top_k"]
+    lines = [
+        "# LEANN Retrieval Backend Comparison",
+        "",
+        f"- Dataset: {summary['dataset']}",
+        f"- Data source: {summary.get('data_source') or 'unknown'}",
+        f"- Data revision: {summary.get('data_revision') or 'unknown'}",
+    ]
+    lines.extend(command_markdown_lines(summary.get("command")))
+    lines.extend(
+        [
+            f"- Queries file: `{summary['queries_file']}`",
+            f"- Queries SHA256: `{summary['queries_sha256']}`",
+            f"- Ground truth file: `{summary['ground_truth_file']}`",
+            f"- Ground truth SHA256: `{summary['ground_truth_sha256']}`",
+            f"- Requested queries: {summary['requested_query_count']}",
+            f"- top_k: {top_k}",
+            f"- complexity: {summary['complexity']}",
+            f"- batch_size: {summary['batch_size']}",
+            "",
+            f"| Run | Backend | Passage IDs | Recall@{top_k} | Hit rate@{top_k} | "
+            "Missing result IDs | Duplicate result-text queries | Duplicate golden-text queries | "
+            "Latency median ms | Latency p95 ms | Storage bytes | Index path |",
+            "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+        ]
+    )
+    for row in summary["runs"]:
+        lines.append(
+            "| {name} | {backend} | {passage_id_scheme} | {recall:.4f} | {hit_rate:.4f} | "
+            "{missing_ids} | {duplicate_results} | {duplicate_golden} | {median:.3f} | "
+            "{p95:.3f} | {storage_bytes} | `{index_path}` |".format(
+                name=_markdown_cell(row["name"]),
+                backend=_markdown_cell(row["backend_name"]),
+                passage_id_scheme=_markdown_cell(row["passage_id_scheme"]),
+                recall=row["recall_at_k"],
+                hit_rate=row["hit_rate_at_k"],
+                missing_ids=row["missing_result_id_count"],
+                duplicate_results=row["queries_with_duplicate_result_texts"],
+                duplicate_golden=row["queries_with_duplicate_golden_texts"],
+                median=row["latency_ms"]["median"],
+                p95=row["latency_ms"]["p95"],
+                storage_bytes=row["storage_bytes"],
+                index_path=_markdown_cell(row["index_path"]),
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_artifact(path: str | Path, content: str) -> None:
+    output_path = Path(path)
+    if output_path.exists() and output_path.is_dir():
+        raise IsADirectoryError(f"comparison output path is a directory: {output_path}")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(content, encoding="utf-8")
+
+
+def _comparison_config(manifest: dict[str, Any], manifest_dir: Path) -> dict[str, Any]:
+    dataset = _required_string(manifest, "dataset")
+    queries_file = _resolve_path(_required_string(manifest, "queries_file"), manifest_dir)
+    ground_truth_file = _resolve_path(_required_string(manifest, "ground_truth_file"), manifest_dir)
+    runs = _comparison_runs(manifest.get("runs"), manifest_dir)
+    return {
+        "dataset": dataset,
+        "queries_file": queries_file,
+        "ground_truth_file": ground_truth_file,
+        "num_queries": _positive_int(manifest, "num_queries", 10),
+        "top_k": _positive_int(manifest, "top_k", 3),
+        "complexity": _positive_int(manifest, "complexity", 120),
+        "batch_size": _non_negative_int(manifest, "batch_size", 0),
+        "data_source": manifest.get("data_source") or "LEANN-RAG/leann-rag-evaluation-data",
+        "data_revision": manifest.get("data_revision"),
+        "runs": runs,
+    }
+
+
+def _comparison_runs(value: Any, manifest_dir: Path) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or len(value) < 2:
+        raise ValueError("comparison manifest must include at least two runs")
+    runs: list[dict[str, Any]] = []
+    names: set[str] = set()
+    for index, run in enumerate(value):
+        if not isinstance(run, dict):
+            raise ValueError(f"runs[{index}] must be a JSON object")
+        name = _required_string(run, "name")
+        if name in names:
+            raise ValueError(f"duplicate run name: {name}")
+        names.add(name)
+        runs.append(
+            {
+                "name": name,
+                "index_path": _resolve_path(_required_string(run, "index_path"), manifest_dir),
+                "backend": run.get("backend"),
+            }
+        )
+    return runs
+
+
+def _comparison_row(run_config: dict[str, Any], summary: dict[str, Any]) -> dict[str, Any]:
+    recall = summary["recall"]
+    latency = summary["latency_ms"]
+    storage = summary["storage"]
+    return {
+        "name": run_config["name"],
+        "manifest_backend": run_config.get("backend"),
+        "backend_name": summary["backend_name"],
+        "index_path": summary["index_path"],
+        "dataset": summary["dataset_type"],
+        "query_count": summary["query_count"],
+        "requested_query_count": summary["requested_query_count"],
+        "top_k": summary["top_k"],
+        "complexity": summary["complexity"],
+        "batch_size": summary["batch_size"],
+        "recall_at_k": recall["recall_at_k"],
+        "hit_rate_at_k": recall["hit_rate_at_k"],
+        "evaluated_queries": recall["evaluated_queries"],
+        "missing_ground_truth_queries": recall["missing_ground_truth_queries"],
+        "missing_golden_passages": recall["missing_golden_passages"],
+        "queries_with_missing_result_ids": recall.get("queries_with_missing_result_ids", 0),
+        "missing_result_id_count": recall.get("missing_result_id_count", 0),
+        "queries_with_duplicate_result_texts": recall.get("queries_with_duplicate_result_texts", 0),
+        "queries_with_duplicate_golden_texts": recall.get("queries_with_duplicate_golden_texts", 0),
+        "latency_ms": latency,
+        "storage_bytes": storage["bytes"],
+        "storage_file_count": len(storage["files"]),
+        "embedding_model": summary["embedding_model"],
+        "embedding_mode": summary["embedding_mode"],
+        "passage_id_scheme": summary["passage_id_scheme"],
+        "leann_commit": summary["environment"].get("leann_commit"),
+        "leann_dirty": summary["environment"].get("leann_dirty"),
+    }
+
+
+def _validate_manifest_backend(run_config: dict[str, Any], summary: dict[str, Any]) -> None:
+    manifest_backend = run_config.get("backend")
+    if manifest_backend and manifest_backend != summary["backend_name"]:
+        raise ValueError(
+            "manifest backend for run "
+            f"'{run_config['name']}' was '{manifest_backend}' but loaded index reported "
+            f"'{summary['backend_name']}'"
+        )
+
+
+def _required_string(mapping: dict[str, Any], key: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"comparison manifest requires non-empty string field: {key}")
+    return value
+
+
+def _positive_int(mapping: dict[str, Any], key: str, default: int) -> int:
+    value = mapping.get(key, default)
+    if not isinstance(value, int) or value <= 0:
+        raise ValueError(f"comparison manifest field {key} must be a positive integer")
+    return value
+
+
+def _non_negative_int(mapping: dict[str, Any], key: str, default: int) -> int:
+    value = mapping.get(key, default)
+    if not isinstance(value, int) or value < 0:
+        raise ValueError(f"comparison manifest field {key} must be a non-negative integer")
+    return value
+
+
+def _resolve_path(value: str, manifest_dir: Path) -> Path:
+    path = Path(value)
+    return path if path.is_absolute() else manifest_dir / path
+
+
+def _markdown_cell(value: Any) -> str:
+    return str(value).replace("|", "\\|")
+
+
+def _validate_output_paths(
+    parser: argparse.ArgumentParser,
+    *,
+    input_paths: list[str | Path],
+    output_paths: list[str | None],
+) -> None:
+    resolved_inputs = {Path(path).resolve() for path in input_paths}
+    seen_outputs: set[Path] = set()
+    for output_path in output_paths:
+        if not output_path:
+            continue
+        resolved_output = Path(output_path).resolve()
+        if resolved_output in resolved_inputs:
+            parser.error("comparison output path must not overwrite an input file")
+        if resolved_output in seen_outputs:
+            parser.error("JSON and Markdown output paths must be different")
+        seen_outputs.add(resolved_output)
+
+
+def main(argv: list[str] | None = None) -> None:
+    command = benchmark_command(__file__, argv)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", help="JSON manifest describing the comparison runs.")
+    parser.add_argument(
+        "--format",
+        choices=["json", "markdown"],
+        default="json",
+        help="Output format for stdout (default: json).",
+    )
+    parser.add_argument("--json-output", help="Write the comparison JSON artifact to this file.")
+    parser.add_argument(
+        "--markdown-output", help="Write the comparison Markdown artifact to this file."
+    )
+    args = parser.parse_args(argv)
+    _validate_output_paths(
+        parser,
+        input_paths=[args.manifest],
+        output_paths=[args.json_output, args.markdown_output],
+    )
+
+    try:
+        manifest_path = Path(args.manifest)
+        manifest = load_manifest(manifest_path)
+        config = _comparison_config(manifest, manifest_path.parent)
+        _validate_output_paths(
+            parser,
+            input_paths=[config["queries_file"], config["ground_truth_file"]],
+            output_paths=[args.json_output, args.markdown_output],
+        )
+        summary = run_comparison(manifest, manifest_dir=manifest_path.parent, command=command)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        parser.error(str(exc))
+
+    if args.json_output:
+        write_artifact(args.json_output, format_summary(summary, "json"))
+    if args.markdown_output:
+        write_artifact(args.markdown_output, format_summary(summary, "markdown"))
+    print(format_summary(summary, args.format), end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/metrics.py
+++ b/benchmarks/metrics.py
@@ -1,0 +1,43 @@
+"""Shared metric helpers for benchmark artifacts."""
+
+from __future__ import annotations
+
+import statistics
+
+
+def mean(values: list[int] | list[float]) -> float:
+    """Return the arithmetic mean, or 0.0 when no samples are available."""
+    return float(sum(values) / len(values)) if values else 0.0
+
+
+def observed_percentile(values: list[float], percentile: float) -> float:
+    """Return a lower nearest-rank observed sample for a percentile.
+
+    Unlike interpolated percentiles, this always returns a value that was actually
+    measured. The helper accepts percentiles in the inclusive [0, 100] range.
+    """
+    if not 0 <= percentile <= 100:
+        raise ValueError("percentile must be between 0 and 100")
+    if not values:
+        return 0.0
+    sorted_values = sorted(values)
+    sample_index = int((percentile / 100.0) * (len(sorted_values) - 1))
+    return sorted_values[sample_index]
+
+
+def timing_stats(values: list[float]) -> dict[str, float]:
+    """Return stable timing summary fields used across benchmark artifacts.
+
+    p95 uses the lower nearest-rank sample from the sorted measurements. This keeps
+    small fixture tests deterministic and avoids interpolating latency samples that
+    were never observed during a benchmark run.
+    """
+    if not values:
+        return {"mean": 0.0, "median": 0.0, "p95": 0.0, "min": 0.0, "max": 0.0}
+    return {
+        "mean": mean(values),
+        "median": statistics.median(values),
+        "p95": observed_percentile(values, 95),
+        "min": min(values),
+        "max": max(values),
+    }

--- a/benchmarks/provenance.py
+++ b/benchmarks/provenance.py
@@ -1,0 +1,75 @@
+"""Shared provenance helpers for benchmark artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import platform
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def environment_metadata() -> dict[str, Any]:
+    """Return local environment metadata for reviewable benchmark artifacts."""
+    return {
+        "leann_commit": _git_commit_sha(),
+        "leann_branch": _git_branch_name(),
+        "leann_dirty": _git_worktree_dirty(),
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+    }
+
+
+def file_sha256(path: str | Path) -> str:
+    """Return the SHA256 hex digest for a benchmark input file."""
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def benchmark_command(script_path: str | Path, argv: list[str] | None) -> str:
+    """Return a repo-relative, shell-quoted benchmark command string."""
+    script = _repo_relative_path(script_path)
+    args = list(argv) if argv is not None else sys.argv[1:]
+    return shlex.join([script, *args])
+
+
+def _repo_relative_path(path: str | Path) -> str:
+    raw_path = Path(path)
+    try:
+        return str(raw_path.resolve().relative_to(Path(__file__).resolve().parents[1]))
+    except (OSError, ValueError):
+        return str(raw_path)
+
+
+def _git_commit_sha() -> str | None:
+    return _git_output(["git", "rev-parse", "HEAD"])
+
+
+def _git_branch_name() -> str | None:
+    return _git_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+
+
+def _git_worktree_dirty() -> bool | None:
+    output = _git_output(["git", "status", "--short"])
+    return None if output is None else bool(output)
+
+
+def _git_output(command: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            command,
+            cwd=Path(__file__).resolve().parents[1],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return result.stdout.strip() or None

--- a/benchmarks/provenance.py
+++ b/benchmarks/provenance.py
@@ -43,9 +43,9 @@ def benchmark_command(script_path: str | Path, argv: list[str] | None) -> str:
 def _repo_relative_path(path: str | Path) -> str:
     raw_path = Path(path)
     try:
-        return str(raw_path.resolve().relative_to(Path(__file__).resolve().parents[1]))
+        return raw_path.resolve().relative_to(Path(__file__).resolve().parents[1]).as_posix()
     except (OSError, ValueError):
-        return str(raw_path)
+        return raw_path.as_posix()
 
 
 def _git_commit_sha() -> str | None:

--- a/benchmarks/run_evaluation.py
+++ b/benchmarks/run_evaluation.py
@@ -10,15 +10,25 @@ import json
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
-import numpy as np
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from leann.api import LeannBuilder, LeannChat, LeannSearcher
+
+from benchmarks.artifact_formatting import command_markdown_lines
+from benchmarks.metrics import mean, timing_stats
+from benchmarks.provenance import benchmark_command, environment_metadata, file_sha256
 
 
 def download_data_if_needed(data_root: Path, download_embeddings: bool = False):
     """Checks if the data directory exists, and if not, downloads it from HF Hub."""
-    if not data_root.exists():
-        print(f"Data directory '{data_root}' not found.")
+    if not _evaluation_data_ready(data_root, download_embeddings=download_embeddings):
+        if data_root.exists():
+            print(f"Data directory '{data_root}' is incomplete.")
+        else:
+            print(f"Data directory '{data_root}' not found.")
         print("Downloading evaluation data from Hugging Face Hub... (this may take a moment)")
         try:
             from huggingface_hub import snapshot_download
@@ -60,6 +70,24 @@ def download_data_if_needed(data_root: Path, download_embeddings: bool = False):
             sys.exit(1)
 
 
+def _evaluation_data_ready(data_root: Path, *, download_embeddings: bool = False) -> bool:
+    required_paths = [
+        data_root / "queries" / "nq_open.jsonl",
+        data_root / "ground_truth",
+    ]
+    if download_embeddings:
+        required_paths.append(data_root / "embeddings")
+    return all(path.exists() for path in required_paths) and _indices_data_ready(
+        data_root / "indices"
+    )
+
+
+def _indices_data_ready(indices_root: Path) -> bool:
+    if not indices_root.is_dir():
+        return False
+    return any(path.is_file() for path in indices_root.rglob("*.index"))
+
+
 def download_embeddings_if_needed(data_root: Path, dataset_type: str | None = None):
     """Download embeddings files specifically."""
     embeddings_dir = data_root / "embeddings"
@@ -98,29 +126,274 @@ def download_embeddings_if_needed(data_root: Path, dataset_type: str | None = No
 
 
 # --- Helper Function to get Golden Passages ---
-def get_golden_texts(searcher: LeannSearcher, golden_ids: list[int]) -> set:
+def get_golden_texts(searcher: LeannSearcher, golden_ids: list[int | str]) -> tuple[set[str], int]:
     """
     Retrieves the text for golden passage IDs directly from the LeannSearcher's
     passage manager.
     """
     golden_texts = set()
+    missing_count = 0
     for gid in golden_ids:
         try:
             # PassageManager uses string IDs
             passage_data = searcher.passage_manager.get_passage(str(gid))
             golden_texts.add(passage_data["text"])
         except KeyError:
+            missing_count += 1
             print(f"Warning: Golden passage ID '{gid}' not found in the index's passage data.")
-    return golden_texts
+    return golden_texts, missing_count
 
 
 def load_queries(file_path: Path) -> list[str]:
     queries = []
     with open(file_path, encoding="utf-8") as f:
-        for line in f:
+        for line_number, line in enumerate(f, start=1):
+            if not line.strip():
+                continue
             data = json.loads(line)
-            queries.append(data["query"])
+            query = data.get("query")
+            if not isinstance(query, str):
+                raise ValueError(f"missing string query at {file_path}:{line_number}")
+            queries.append(query)
     return queries
+
+
+def run_retrieval_evaluation(
+    searcher: LeannSearcher,
+    queries: list[str],
+    golden_results_data: dict[str, Any],
+    *,
+    index_path: str,
+    dataset_type: str,
+    queries_file: str | Path,
+    ground_truth_file: str | Path,
+    num_queries: int,
+    top_k: int,
+    complexity: int,
+    batch_size: int,
+    run_llm: bool = False,
+    llm_type: str = "ollama",
+    llm_model: str = "qwen3:1.7b",
+    data_source: str = "LEANN-RAG/leann-rag-evaluation-data",
+    data_revision: str | None = None,
+    queries_sha256: str | None = None,
+    ground_truth_sha256: str | None = None,
+    command: str | None = None,
+) -> dict[str, Any]:
+    """Run retrieval-only recall evaluation and return a reviewable summary."""
+    if num_queries <= 0:
+        raise ValueError("num_queries must be greater than 0")
+    if top_k <= 0:
+        raise ValueError("top_k must be greater than 0")
+    if complexity <= 0:
+        raise ValueError("complexity must be greater than 0")
+    if batch_size < 0:
+        raise ValueError("batch_size must be greater than or equal to 0")
+
+    eval_queries = queries[: min(num_queries, len(queries))]
+    per_query: list[dict[str, Any]] = []
+    recall_scores: list[float] = []
+    hits = 0
+    missing_ground_truth_queries = 0
+    missing_golden_passages = 0
+    queries_with_missing_result_ids = 0
+    missing_result_id_count = 0
+    queries_with_duplicate_result_texts = 0
+    queries_with_duplicate_golden_texts = 0
+
+    chat = None
+    if run_llm:
+        llm_config = {"type": llm_type, "model": llm_model}
+        chat = LeannChat(index_path, llm_config=llm_config, searcher=searcher)
+
+    for query_index, query in enumerate(eval_queries):
+        started = time.perf_counter()
+        new_results = searcher.search(
+            query,
+            top_k=top_k,
+            complexity=complexity,
+            batch_size=batch_size,
+        )
+        latency_ms = (time.perf_counter() - started) * 1000
+
+        answer = None
+        if chat is not None:
+            answer = chat.ask(
+                query,
+                top_k=top_k,
+                complexity=complexity,
+                batch_size=batch_size,
+            )
+
+        result_ids = _result_ids(new_results)
+        missing_result_ids = len(new_results) - len(result_ids)
+        if missing_result_ids:
+            queries_with_missing_result_ids += 1
+            missing_result_id_count += missing_result_ids
+        new_texts = {result.text for result in new_results}
+        result_duplicate_text_count = len(new_results) - len(new_texts)
+        if result_duplicate_text_count:
+            queries_with_duplicate_result_texts += 1
+        golden_ids = _golden_ids_for_query(golden_results_data, query_index, top_k)
+        if not golden_ids:
+            per_query.append(
+                {
+                    "query_index": query_index,
+                    "result_ids": result_ids,
+                    "result_count": len(new_results),
+                    "missing_result_id_count": missing_result_ids,
+                    "result_duplicate_text_count": result_duplicate_text_count,
+                    "golden_ids": [],
+                    "golden_count": 0,
+                    "golden_duplicate_text_count": 0,
+                    "overlap": 0,
+                    "recall": None,
+                    "latency_ms": latency_ms,
+                    "missing_ground_truth": True,
+                }
+            )
+            missing_ground_truth_queries += 1
+            continue
+        golden_texts, missing_count = get_golden_texts(searcher, golden_ids)
+        missing_golden_passages += missing_count
+        golden_duplicate_text_count = max(0, len(golden_ids) - missing_count - len(golden_texts))
+        if golden_duplicate_text_count:
+            queries_with_duplicate_golden_texts += 1
+
+        overlap = len(new_texts & golden_texts)
+        recall = overlap / len(golden_texts) if golden_texts else 0.0
+        recall_scores.append(recall)
+        if overlap:
+            hits += 1
+
+        row: dict[str, Any] = {
+            "query_index": query_index,
+            "result_ids": result_ids,
+            "result_count": len(new_results),
+            "missing_result_id_count": missing_result_ids,
+            "result_duplicate_text_count": result_duplicate_text_count,
+            "golden_ids": [str(item) for item in golden_ids],
+            "golden_count": len(golden_texts),
+            "golden_duplicate_text_count": golden_duplicate_text_count,
+            "overlap": overlap,
+            "recall": recall,
+            "latency_ms": latency_ms,
+            "missing_ground_truth": False,
+        }
+        if answer is not None:
+            row["answer"] = answer
+        per_query.append(row)
+
+    latency_values = [row["latency_ms"] for row in per_query]
+    summary = {
+        "schema_version": 2,
+        "benchmark": "retrieval_evaluation",
+        "mode": "retrieval_with_llm" if run_llm else "retrieval_only",
+        "dataset": dataset_type,
+        "dataset_type": dataset_type,
+        "data_source": data_source,
+        "data_revision": data_revision,
+        "command": command,
+        "index_path": str(index_path),
+        "queries_file": str(queries_file),
+        "queries_sha256": queries_sha256,
+        "ground_truth_file": str(ground_truth_file),
+        "ground_truth_sha256": ground_truth_sha256,
+        "query_count": len(eval_queries),
+        "requested_query_count": num_queries,
+        "top_k": top_k,
+        "complexity": complexity,
+        "batch_size": batch_size,
+        "run_llm": run_llm,
+        "llm_used": run_llm,
+        "llm_type": llm_type if run_llm else None,
+        "llm_model": llm_model if run_llm else None,
+        "backend_name": getattr(searcher, "backend_name", "unknown"),
+        "embedding_model": getattr(searcher, "embedding_model", "unknown"),
+        "embedding_mode": getattr(searcher, "embedding_mode", "unknown"),
+        "passage_id_scheme": getattr(searcher, "passage_id_scheme", "unknown"),
+        "average_result_count": mean([row["result_count"] for row in per_query]),
+        "evaluated_queries": len(recall_scores),
+        "missing_ground_truth_queries": missing_ground_truth_queries,
+        "recall": {
+            "evaluated_queries": len(recall_scores),
+            "missing_ground_truth_queries": missing_ground_truth_queries,
+            "missing_golden_passages": missing_golden_passages,
+            "queries_with_missing_result_ids": queries_with_missing_result_ids,
+            "missing_result_id_count": missing_result_id_count,
+            "queries_with_duplicate_result_texts": queries_with_duplicate_result_texts,
+            "queries_with_duplicate_golden_texts": queries_with_duplicate_golden_texts,
+            "recall_at_k": mean(recall_scores),
+            "hit_rate_at_k": hits / len(recall_scores) if recall_scores else 0.0,
+        },
+        "latency_ms": timing_stats(latency_values),
+        "storage": _index_storage(index_path),
+        "environment": environment_metadata(),
+        "per_query": per_query,
+    }
+    return summary
+
+
+def format_summary(summary: dict[str, Any], output_format: str) -> str:
+    if output_format == "json":
+        return json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    if output_format == "markdown":
+        return format_markdown(summary)
+    raise ValueError(f"unsupported output format: {output_format}")
+
+
+def format_markdown(summary: dict[str, Any]) -> str:
+    recall = summary["recall"]
+    latency = summary["latency_ms"]
+    storage = summary["storage"]
+    lines = [
+        "# LEANN Retrieval Evaluation",
+        "",
+        f"- Dataset: {summary['dataset_type']}",
+        f"- Data source: {summary.get('data_source') or 'unknown'}",
+        f"- Data revision: {summary.get('data_revision') or 'unknown'}",
+    ]
+    lines.extend(command_markdown_lines(summary.get("command")))
+    lines.extend(
+        [
+            f"- Index path: `{summary['index_path']}`",
+            f"- Queries SHA256: `{summary.get('queries_sha256') or 'unavailable'}`",
+            f"- Ground truth SHA256: `{summary.get('ground_truth_sha256') or 'unavailable'}`",
+            f"- Backend: {summary['backend_name']}",
+            f"- Embedding model: {summary['embedding_model']}",
+            f"- Queries: {summary['query_count']} of requested {summary['requested_query_count']}",
+            f"- top_k: {summary['top_k']}",
+            f"- complexity: {summary['complexity']}",
+            f"- batch_size: {summary['batch_size']}",
+            f"- LLM generation: {summary['llm_used']}",
+            f"- Evaluated recall queries: {recall['evaluated_queries']}",
+            f"- Missing ground-truth queries: {recall['missing_ground_truth_queries']}",
+            f"- Recall@{summary['top_k']}: {recall['recall_at_k']:.4f}",
+            f"- Hit rate@{summary['top_k']}: {recall['hit_rate_at_k']:.4f}",
+            f"- Missing golden passages: {recall['missing_golden_passages']}",
+            f"- Queries with missing result IDs: {recall['queries_with_missing_result_ids']}",
+            f"- Missing result ID count: {recall['missing_result_id_count']}",
+            f"- Queries with duplicate result text: {recall['queries_with_duplicate_result_texts']}",
+            f"- Queries with duplicate golden text: {recall['queries_with_duplicate_golden_texts']}",
+            f"- Average result count: {summary['average_result_count']:.3f}",
+            "- Latency ms: "
+            f"mean={latency['mean']:.3f}, median={latency['median']:.3f}, "
+            f"p95={latency['p95']:.3f}, min={latency['min']:.3f}, max={latency['max']:.3f}",
+        ]
+    )
+    if storage["exists"]:
+        lines.append(f"- Storage bytes: {storage['bytes']}")
+    else:
+        lines.append("- Storage bytes: unavailable")
+    return "\n".join(lines) + "\n"
+
+
+def write_summary_artifact(path: str | Path, content: str) -> None:
+    output_path = Path(path)
+    if output_path.exists() and output_path.is_dir():
+        raise IsADirectoryError(f"summary output path is a directory: {output_path}")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(content, encoding="utf-8")
 
 
 def build_index_from_embeddings(embeddings_file: str, output_path: str, backend: str = "hnsw"):
@@ -165,7 +438,78 @@ def build_index_from_embeddings(embeddings_file: str, output_path: str, backend:
     return output_path
 
 
-def main():
+def _golden_ids_for_query(
+    golden_results_data: dict[str, Any],
+    query_index: int,
+    top_k: int,
+) -> list[int | str]:
+    indices = golden_results_data.get("indices")
+    if not isinstance(indices, list) or query_index >= len(indices):
+        return []
+    row = indices[query_index]
+    if not isinstance(row, list):
+        return []
+    return row[:top_k]
+
+
+def _result_ids(results: list[Any]) -> list[str]:
+    ids: list[str] = []
+    for result in results:
+        result_id = getattr(result, "id", None)
+        if result_id is not None:
+            ids.append(str(result_id))
+    return ids
+
+
+def _index_storage(index_path: str | Path) -> dict[str, Any]:
+    path = Path(index_path)
+    parent = path.parent
+    logical_name = path.name
+    native_stem = path.stem
+    files: list[Path] = []
+    if parent.exists():
+        for candidate in parent.iterdir():
+            if not candidate.is_file():
+                continue
+            if _is_index_artifact(candidate.name, logical_name, native_stem):
+                files.append(candidate)
+    return {
+        "index_path": str(path),
+        "exists": bool(files),
+        "bytes": sum(file.stat().st_size for file in files),
+        "files": [str(file) for file in sorted(files)],
+    }
+
+
+def _is_index_artifact(filename: str, logical_name: str, native_stem: str) -> bool:
+    return (
+        filename == logical_name
+        or filename.startswith(f"{logical_name}.")
+        or filename in {f"{native_stem}.index", f"{native_stem}.ids.txt"}
+    )
+
+
+def _validate_output_paths(
+    parser: argparse.ArgumentParser,
+    *,
+    input_paths: list[str | Path],
+    output_paths: list[str | None],
+) -> None:
+    resolved_inputs = {Path(path).resolve() for path in input_paths}
+    seen_outputs: set[Path] = set()
+    for output_path in output_paths:
+        if not output_path:
+            continue
+        resolved_output = Path(output_path).resolve()
+        if resolved_output in resolved_inputs:
+            parser.error("summary output path must not overwrite an input file")
+        if resolved_output in seen_outputs:
+            parser.error("JSON and Markdown output paths must be different")
+        seen_outputs.add(resolved_output)
+
+
+def main(argv: list[str] | None = None) -> None:
+    command = benchmark_command(__file__, argv)
     parser = argparse.ArgumentParser(description="Run recall evaluation on a LEANN index.")
     parser.add_argument(
         "index_path",
@@ -195,7 +539,12 @@ def main():
     )
     parser.add_argument("--top-k", type=int, default=3, help="The 'k' value for recall@k.")
     parser.add_argument(
-        "--ef-search", type=int, default=120, help="The 'efSearch' parameter for HNSW."
+        "--complexity",
+        "--ef-search",
+        dest="complexity",
+        type=int,
+        default=120,
+        help="Search complexity parameter forwarded to LeannSearcher.search (default: 120).",
     )
     parser.add_argument(
         "--batch-size",
@@ -214,9 +563,64 @@ def main():
         "--llm-model",
         type=str,
         default="qwen3:1.7b",
-        help="LLM model identifier for the chosen backend (default: qwen3:1.7b)",
+        help="LLM model identifier used with --run-llm (default: qwen3:1.7b)",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--run-llm",
+        action="store_true",
+        help="Also run LeannChat generation after retrieval. Excluded from retrieval latency.",
+    )
+    parser.add_argument(
+        "--evaluate-after-build",
+        action="store_true",
+        help="In build mode, run evaluation after building. Build mode exits after build by default.",
+    )
+    parser.add_argument(
+        "--dataset",
+        help="Dataset label for artifact metadata. Defaults to inferred index-path label.",
+    )
+    parser.add_argument(
+        "--queries-file",
+        type=Path,
+        help="JSONL queries file. Defaults to benchmarks/data/queries/nq_open.jsonl.",
+    )
+    parser.add_argument(
+        "--ground-truth",
+        type=Path,
+        help="Ground-truth JSON file. Defaults to benchmarks/data/ground_truth/<dataset>/flat_results_nq_k3.json.",
+    )
+    parser.add_argument(
+        "--data-source",
+        default="LEANN-RAG/leann-rag-evaluation-data",
+        help="Dataset/source identifier recorded in benchmark artifacts.",
+    )
+    parser.add_argument(
+        "--data-revision",
+        help="Dataset revision, commit, snapshot, or download date recorded in benchmark artifacts.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["json", "markdown"],
+        default="json",
+        help="Output format for stdout in evaluate mode (default: json).",
+    )
+    parser.add_argument(
+        "--json-output",
+        help="Write the evaluation summary JSON artifact to this file.",
+    )
+    parser.add_argument(
+        "--markdown-output",
+        help="Write the evaluation summary Markdown artifact to this file.",
+    )
+    args = parser.parse_args(argv)
+    if args.num_queries <= 0:
+        parser.error("--num-queries must be greater than 0")
+    if args.top_k <= 0:
+        parser.error("--top-k must be greater than 0")
+    if args.complexity <= 0:
+        parser.error("--complexity must be greater than 0")
+    if args.batch_size < 0:
+        parser.error("--batch-size must be greater than or equal to 0")
 
     # --- Path Configuration ---
     # Assumes a project structure where the script is in 'benchmarks/'
@@ -267,9 +671,7 @@ def main():
         )
         print(f"Index built successfully: {built_index_path}")
 
-        # Ask if user wants to run evaluation
-        eval_response = input("Run evaluation on the built index? (y/n): ").strip().lower()
-        if eval_response != "y":
+        if not args.evaluate_after_build:
             print("Index building complete. Exiting.")
             return
     else:
@@ -305,7 +707,9 @@ def main():
 
     # Detect dataset type from index path to select the correct ground truth
     index_path_str = str(args.index_path)
-    if "rpj_wiki" in index_path_str:
+    if args.dataset:
+        dataset_type = args.dataset
+    elif "rpj_wiki" in index_path_str:
         dataset_type = "rpj_wiki"
     elif "dpr" in index_path_str:
         dataset_type = "dpr"
@@ -314,8 +718,15 @@ def main():
         dataset_type = Path(args.index_path).name
         print(f"WARNING: Could not detect dataset type from path, inferred '{dataset_type}'.")
 
-    queries_file = data_root / "queries" / "nq_open.jsonl"
-    golden_results_file = data_root / "ground_truth" / dataset_type / "flat_results_nq_k3.json"
+    queries_file = args.queries_file or data_root / "queries" / "nq_open.jsonl"
+    golden_results_file = (
+        args.ground_truth or data_root / "ground_truth" / dataset_type / "flat_results_nq_k3.json"
+    )
+    _validate_output_paths(
+        parser,
+        input_paths=[queries_file, golden_results_file],
+        output_paths=[args.json_output, args.markdown_output],
+    )
 
     print(f"INFO: Detected dataset type: {dataset_type}")
     print(f"INFO: Using queries file: {queries_file}")
@@ -323,7 +734,11 @@ def main():
 
     try:
         searcher = LeannSearcher(args.index_path)
+        queries_sha256 = file_sha256(queries_file)
+        ground_truth_sha256 = file_sha256(golden_results_file)
         queries = load_queries(queries_file)
+        if not queries:
+            parser.error("queries file did not contain any queries")
 
         with open(golden_results_file) as f:
             golden_results_data = json.load(f)
@@ -331,62 +746,39 @@ def main():
         num_eval_queries = min(args.num_queries, len(queries))
         queries = queries[:num_eval_queries]
 
-        print(f"\nRunning evaluation on {num_eval_queries} queries...")
-        recall_scores = []
-        search_times = []
-
-        for i in range(num_eval_queries):
-            start_time = time.time()
-            new_results = searcher.search(
-                queries[i],
-                top_k=args.top_k,
-                complexity=args.ef_search,
-                batch_size=args.batch_size,
-            )
-            search_times.append(time.time() - start_time)
-
-            # Optional: also call the LLM with configurable backend/model (does not affect recall)
-            llm_config = {"type": args.llm_type, "model": args.llm_model}
-            chat = LeannChat(args.index_path, llm_config=llm_config, searcher=searcher)
-            answer = chat.ask(
-                queries[i],
-                top_k=args.top_k,
-                complexity=args.ef_search,
-                batch_size=args.batch_size,
-            )
-            print(f"Answer: {answer}")
-            # Correct Recall Calculation: Based on TEXT content
-            new_texts = {result.text for result in new_results}
-
-            # Get golden texts directly from the searcher's passage manager
-            golden_ids = golden_results_data["indices"][i][: args.top_k]
-            golden_texts = get_golden_texts(searcher, golden_ids)
-
-            overlap = len(new_texts & golden_texts)
-            recall = overlap / len(golden_texts) if golden_texts else 0
-            recall_scores.append(recall)
-
-            print("\n--- EVALUATION RESULTS ---")
-            print(f"Query: {queries[i]}")
-            print(f"New Results: {new_texts}")
-            print(f"Golden Results: {golden_texts}")
-            print(f"Overlap: {overlap}")
-            print(f"Recall: {recall}")
-            print(f"Search Time: {search_times[-1]:.4f}s")
-            print("--------------------------------")
-
-        avg_recall = np.mean(recall_scores) if recall_scores else 0
-        avg_time = np.mean(search_times) if search_times else 0
-
-        print("\n🎉 --- Evaluation Complete ---")
-        print(f"Avg. Recall@{args.top_k} (efSearch={args.ef_search}): {avg_recall:.4f}")
-        print(f"Avg. Search Time: {avg_time:.4f}s")
+        summary = run_retrieval_evaluation(
+            searcher,
+            queries,
+            golden_results_data,
+            index_path=args.index_path,
+            dataset_type=dataset_type,
+            queries_file=queries_file,
+            ground_truth_file=golden_results_file,
+            num_queries=args.num_queries,
+            top_k=args.top_k,
+            complexity=args.complexity,
+            batch_size=args.batch_size,
+            run_llm=args.run_llm,
+            llm_type=args.llm_type,
+            llm_model=args.llm_model,
+            data_source=args.data_source,
+            data_revision=args.data_revision,
+            queries_sha256=queries_sha256,
+            ground_truth_sha256=ground_truth_sha256,
+            command=command,
+        )
+        if args.json_output:
+            write_summary_artifact(args.json_output, format_summary(summary, "json"))
+        if args.markdown_output:
+            write_summary_artifact(args.markdown_output, format_summary(summary, "markdown"))
+        print(format_summary(summary, args.format), end="")
 
     except Exception as e:
         print(f"\n❌ An error occurred during evaluation: {e}")
         import traceback
 
         traceback.print_exc()
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/benchmarks/run_evaluation.py
+++ b/benchmarks/run_evaluation.py
@@ -10,7 +10,7 @@ import json
 import sys
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, cast
 
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -20,6 +20,27 @@ from leann.api import LeannBuilder, LeannChat, LeannSearcher
 from benchmarks.artifact_formatting import command_markdown_lines
 from benchmarks.metrics import mean, timing_stats
 from benchmarks.provenance import benchmark_command, environment_metadata, file_sha256
+
+
+class PassageManagerLike(Protocol):
+    def get_passage(self, passage_id: str) -> dict[str, Any]: ...
+
+
+class RetrievalSearcherLike(Protocol):
+    backend_name: str
+    embedding_model: str
+    embedding_mode: str
+    passage_id_scheme: str
+    passage_manager: PassageManagerLike
+
+    def search(
+        self,
+        query: str,
+        *,
+        top_k: int,
+        complexity: int,
+        batch_size: int,
+    ) -> list[Any]: ...
 
 
 def download_data_if_needed(data_root: Path, download_embeddings: bool = False):
@@ -126,7 +147,10 @@ def download_embeddings_if_needed(data_root: Path, dataset_type: str | None = No
 
 
 # --- Helper Function to get Golden Passages ---
-def get_golden_texts(searcher: LeannSearcher, golden_ids: list[int | str]) -> tuple[set[str], int]:
+def get_golden_texts(
+    searcher: RetrievalSearcherLike,
+    golden_ids: list[int | str],
+) -> tuple[set[str], int]:
     """
     Retrieves the text for golden passage IDs directly from the LeannSearcher's
     passage manager.
@@ -159,7 +183,7 @@ def load_queries(file_path: Path) -> list[str]:
 
 
 def run_retrieval_evaluation(
-    searcher: LeannSearcher,
+    searcher: RetrievalSearcherLike,
     queries: list[str],
     golden_results_data: dict[str, Any],
     *,
@@ -204,7 +228,11 @@ def run_retrieval_evaluation(
     chat = None
     if run_llm:
         llm_config = {"type": llm_type, "model": llm_model}
-        chat = LeannChat(index_path, llm_config=llm_config, searcher=searcher)
+        chat = LeannChat(
+            index_path,
+            llm_config=llm_config,
+            searcher=cast(LeannSearcher, searcher),
+        )
 
     for query_index, query in enumerate(eval_queries):
         started = time.perf_counter()

--- a/benchmarks/storage.py
+++ b/benchmarks/storage.py
@@ -1,0 +1,19 @@
+"""Storage accounting helpers for benchmark artifacts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def directory_storage(path: str | Path) -> dict[str, object]:
+    """Return recursive storage statistics for a benchmark data directory."""
+    root = Path(path)
+    files = (
+        [candidate for candidate in root.rglob("*") if candidate.is_file()] if root.exists() else []
+    )
+    return {
+        "path": str(root.resolve()),
+        "exists": root.exists(),
+        "bytes": sum(file.stat().st_size for file in files),
+        "file_count": len(files),
+    }

--- a/benchmarks/summarize_query_log.py
+++ b/benchmarks/summarize_query_log.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Summarize LEANN query logs into reproducible benchmark metrics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from benchmarks.artifact_formatting import command_markdown_lines
+from benchmarks.metrics import mean, timing_stats
+from benchmarks.provenance import benchmark_command, environment_metadata
+
+GROUND_TRUTH_KEYS = ("relevant_ids", "gold_ids", "expected_ids", "ids")
+LATENCY_KEYS = ("duration_ms", "latency_ms", "search_ms")
+
+
+def load_query_log(path: str | Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            if isinstance(record, dict):
+                records.append(record)
+    return records
+
+
+def load_ground_truth(path: str | Path) -> dict[str, set[str]]:
+    raw_path = Path(path)
+    if raw_path.suffix == ".jsonl":
+        rows = []
+        with open(raw_path, encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    rows.append(json.loads(line))
+        return _ground_truth_from_rows(rows)
+
+    data = json.loads(raw_path.read_text(encoding="utf-8"))
+    if isinstance(data, dict):
+        return {
+            str(query): {str(item) for item in ids}
+            for query, ids in data.items()
+            if isinstance(ids, list)
+        }
+    if isinstance(data, list):
+        return _ground_truth_from_rows(data)
+    raise ValueError("ground truth must be a JSON object, JSON list, or JSONL records")
+
+
+def summarize_query_log(
+    records: list[dict[str, Any]],
+    *,
+    ground_truth: dict[str, set[str]] | None = None,
+    k: int = 10,
+    index_paths: list[str | Path] | None = None,
+    data_source: str | None = None,
+    data_revision: str | None = None,
+    command: str | None = None,
+) -> dict[str, Any]:
+    result_ids_by_record = [_result_ids(record) for record in records]
+    result_counts = [len(ids) for ids in result_ids_by_record]
+    result_id_gaps = [_result_id_gap_count(record) for record in records]
+    latency_values = [_latency_ms(record) for record in records]
+    latency_values = [value for value in latency_values if value is not None]
+    summary: dict[str, Any] = {
+        "schema_version": 2,
+        "benchmark": "query_log_summary",
+        "data_source": data_source,
+        "data_revision": data_revision,
+        "command": command,
+        "query_count": len(records),
+        "k": k,
+        "average_result_count": mean(result_counts),
+        "records_with_missing_result_ids": sum(1 for count in result_id_gaps if count),
+        "missing_result_id_count": sum(result_id_gaps),
+        "records_missing_latency": len(records) - len(latency_values),
+        "records_missing_search_mode": sum(
+            1 for record in records if not record.get("search_mode")
+        ),
+        "records_missing_backend_name": sum(
+            1 for record in records if not record.get("backend_name")
+        ),
+        "search_modes": dict(
+            Counter(str(record.get("search_mode", "unknown")) for record in records)
+        ),
+        "backends": dict(Counter(str(record.get("backend_name", "unknown")) for record in records)),
+    }
+    if latency_values:
+        summary["latency_ms"] = timing_stats(latency_values)
+    if ground_truth is not None:
+        summary["recall"] = _recall_summary(records, ground_truth, k=k)
+
+    paths = list(index_paths or [])
+    if not paths:
+        paths = sorted(
+            {
+                record["index_path"]
+                for record in records
+                if isinstance(record.get("index_path"), str) and record["index_path"]
+            }
+        )
+    storage = [_index_storage(path) for path in paths]
+    storage = [item for item in storage if item["exists"]]
+    if storage:
+        summary["storage"] = {
+            "indexes": storage,
+            "total_bytes": sum(item["bytes"] for item in storage),
+        }
+    summary["environment"] = environment_metadata()
+    return summary
+
+
+def format_summary(summary: dict[str, Any], output_format: str) -> str:
+    if output_format == "json":
+        return json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    if output_format == "markdown":
+        return format_markdown(summary)
+    raise ValueError(f"unsupported output format: {output_format}")
+
+
+def format_markdown(summary: dict[str, Any]) -> str:
+    lines = [
+        "# LEANN Query Log Summary",
+        "",
+        f"- Data source: {summary.get('data_source') or 'unknown'}",
+        f"- Data revision: {summary.get('data_revision') or 'unknown'}",
+    ]
+    lines.extend(command_markdown_lines(summary.get("command")))
+    lines.extend(
+        [
+            f"- Queries: {summary['query_count']}",
+            f"- k: {summary['k']}",
+            f"- Average result count: {summary['average_result_count']:.3f}",
+            f"- Search modes: {json.dumps(summary['search_modes'], sort_keys=True)}",
+            f"- Backends: {json.dumps(summary['backends'], sort_keys=True)}",
+        ]
+    )
+    if "recall" in summary:
+        recall = summary["recall"]
+        lines.extend(
+            [
+                f"- Evaluated recall queries: {recall['evaluated_queries']}",
+                f"- Recall@{summary['k']}: {recall['recall_at_k']:.3f}",
+                f"- Hit rate@{summary['k']}: {recall['hit_rate_at_k']:.3f}",
+            ]
+        )
+    if "latency_ms" in summary:
+        latency = summary["latency_ms"]
+        lines.append(
+            "- Latency ms: "
+            f"mean={latency['mean']:.3f}, median={latency['median']:.3f}, "
+            f"p95={latency['p95']:.3f}, min={latency['min']:.3f}, max={latency['max']:.3f}"
+        )
+    lines.extend(
+        [
+            f"- Records with missing result IDs: {summary['records_with_missing_result_ids']}",
+            f"- Missing result ID count: {summary['missing_result_id_count']}",
+            f"- Records missing latency: {summary['records_missing_latency']}",
+            f"- Records missing search mode: {summary['records_missing_search_mode']}",
+            f"- Records missing backend name: {summary['records_missing_backend_name']}",
+        ]
+    )
+    if "storage" in summary:
+        lines.append(f"- Storage bytes: {summary['storage']['total_bytes']}")
+    return "\n".join(lines) + "\n"
+
+
+def write_summary_artifact(path: str | Path, content: str) -> None:
+    output_path = Path(path)
+    if output_path.exists() and output_path.is_dir():
+        raise IsADirectoryError(f"summary output path is a directory: {output_path}")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(content, encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> None:
+    command = benchmark_command(__file__, argv)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("query_log", help="LEANN query log JSONL path")
+    parser.add_argument("--ground-truth", help="JSON/JSONL mapping queries to relevant IDs")
+    parser.add_argument("--k", type=int, default=10, help="Recall cutoff (default: 10)")
+    parser.add_argument(
+        "--index-path",
+        action="append",
+        default=[],
+        help="Logical .leann index path to include in storage accounting. May repeat.",
+    )
+    parser.add_argument(
+        "--data-source",
+        help="Dataset/source identifier recorded in benchmark summary artifacts.",
+    )
+    parser.add_argument(
+        "--data-revision",
+        help="Dataset revision, commit, snapshot, or download date recorded in benchmark summaries.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["json", "markdown"],
+        default="json",
+        help="Output format (default: json)",
+    )
+    parser.add_argument(
+        "--json-output",
+        help="Write the benchmark summary JSON artifact to this file.",
+    )
+    parser.add_argument(
+        "--markdown-output",
+        help="Write the benchmark summary Markdown artifact to this file.",
+    )
+    args = parser.parse_args(argv)
+    if args.k <= 0:
+        parser.error("--k must be greater than 0")
+
+    ground_truth = load_ground_truth(args.ground_truth) if args.ground_truth else None
+    summary = summarize_query_log(
+        load_query_log(args.query_log),
+        ground_truth=ground_truth,
+        k=args.k,
+        index_paths=args.index_path,
+        data_source=args.data_source,
+        data_revision=args.data_revision,
+        command=command,
+    )
+    query_log_path = Path(args.query_log).resolve()
+    protected_inputs = [query_log_path]
+    if args.ground_truth:
+        protected_inputs.append(Path(args.ground_truth).resolve())
+    for output_path in (args.json_output, args.markdown_output):
+        if output_path and Path(output_path).resolve() in protected_inputs:
+            parser.error("summary output path must not overwrite an input file")
+    if (
+        args.json_output
+        and args.markdown_output
+        and Path(args.json_output).resolve() == Path(args.markdown_output).resolve()
+    ):
+        parser.error("JSON and Markdown output paths must be different")
+
+    if args.json_output:
+        write_summary_artifact(args.json_output, format_summary(summary, "json"))
+    if args.markdown_output:
+        write_summary_artifact(args.markdown_output, format_summary(summary, "markdown"))
+    print(format_summary(summary, args.format), end="")
+
+
+def _ground_truth_from_rows(rows: list[Any]) -> dict[str, set[str]]:
+    ground_truth: dict[str, set[str]] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        query = row.get("query") or row.get("question")
+        if not isinstance(query, str):
+            continue
+        for key in GROUND_TRUTH_KEYS:
+            ids = row.get(key)
+            if isinstance(ids, list):
+                ground_truth[query] = {str(item) for item in ids}
+                break
+    return ground_truth
+
+
+def _recall_summary(
+    records: list[dict[str, Any]],
+    ground_truth: dict[str, set[str]],
+    *,
+    k: int,
+) -> dict[str, Any]:
+    recalls: list[float] = []
+    hits = 0
+    missing_queries = 0
+    for record in records:
+        query = record.get("query")
+        relevant = ground_truth.get(str(query))
+        if not relevant:
+            missing_queries += 1
+            continue
+        returned = set(_result_ids(record)[:k])
+        overlap = returned & relevant
+        recalls.append(len(overlap) / len(relevant))
+        if overlap:
+            hits += 1
+    return {
+        "evaluated_queries": len(recalls),
+        "missing_queries": missing_queries,
+        "recall_at_k": mean(recalls),
+        "hit_rate_at_k": hits / len(recalls) if recalls else 0.0,
+    }
+
+
+def _result_ids(record: dict[str, Any]) -> list[str]:
+    results = record.get("results")
+    if not isinstance(results, list):
+        return []
+    ids: list[str] = []
+    for result in results:
+        if isinstance(result, dict) and result.get("id") is not None:
+            ids.append(str(result["id"]))
+    return ids
+
+
+def _result_id_gap_count(record: dict[str, Any]) -> int:
+    results = record.get("results")
+    if results is None:
+        return 0
+    if not isinstance(results, list):
+        return 1
+    return sum(1 for result in results if not isinstance(result, dict) or result.get("id") is None)
+
+
+def _latency_ms(record: dict[str, Any]) -> float | None:
+    for key in LATENCY_KEYS:
+        value = record.get(key)
+        if isinstance(value, (int, float)):
+            return float(value)
+    return None
+
+
+def _index_storage(index_path: str | Path) -> dict[str, Any]:
+    path = Path(index_path)
+    parent = path.parent
+    logical_name = path.name
+    native_stem = path.stem
+    files: list[Path] = []
+    if parent.exists():
+        for candidate in parent.iterdir():
+            if not candidate.is_file():
+                continue
+            if _is_index_artifact(candidate.name, logical_name, native_stem):
+                files.append(candidate)
+    return {
+        "index_path": str(path),
+        "exists": bool(files),
+        "bytes": sum(file.stat().st_size for file in files),
+        "files": [str(file) for file in sorted(files)],
+    }
+
+
+def _is_index_artifact(filename: str, logical_name: str, native_stem: str) -> bool:
+    return (
+        filename == logical_name
+        or filename.startswith(f"{logical_name}.")
+        or filename in {f"{native_stem}.index", f"{native_stem}.ids.txt"}
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,229 @@
+# Benchmarks
+
+This page inventories the benchmark entry points currently available in this repository. It is a
+documentation scaffold for the P0 benchmark roadmap item; it does not claim that every suite is
+fully automated in CI or that historical numbers have been freshly reproduced on the current
+branch.
+
+## Quick Local Checks
+
+These scripts are the best first stop when checking backend behavior on a developer machine.
+
+| Area | Entry point | What it measures | Notes |
+| --- | --- | --- | --- |
+| Backend latency and size | `benchmarks/diskann_vs_hnsw_speed_comparison.py` | DiskANN vs HNSW search latency, build time, and index size | Accepts optional document and query counts. |
+| Storage comparison | `benchmarks/compare_faiss_vs_leann.py` | LEANN storage savings against a FAISS baseline | Good for a quick sanity check of the storage story. |
+| Embedding throughput | `benchmarks/benchmark_embeddings.py` | Embedding provider throughput | Depends on the configured local/provider model. |
+| No-recompute baseline | `benchmarks/benchmark_no_recompute.py` | Search behavior when stored embeddings are available | Useful when isolating recompute overhead. |
+| Retrieval backend comparison | `benchmarks/compare_retrieval_backends.py` | Recall, hit rate, latency, and storage for multiple prebuilt indexes under one manifest | Evaluation-only; does not build indexes. |
+
+Example:
+
+```bash
+uv run python benchmarks/diskann_vs_hnsw_speed_comparison.py
+uv run python benchmarks/compare_faiss_vs_leann.py
+```
+
+## Curated Reports
+
+Curated benchmark reports should be committed only when they include the full command, data source,
+revision, environment, and result context needed for review. Generated artifacts under
+`benchmark-results/` should remain local unless they are intentionally promoted into a documented
+report.
+
+## P0 Benchmark Acceptance Checklist
+
+The P0 benchmark roadmap item is not complete until at least one reviewable benchmark pack includes
+real retrieval results, not just synthetic helper metrics. A benchmark pack should contain:
+
+- A retrieval evaluation artifact from `benchmarks/run_evaluation.py` with JSON and Markdown
+  outputs.
+- A query-log summary from `benchmarks/summarize_query_log.py` when replay logs are used for
+  comparison.
+- Dataset name, corpus size, query count, ground-truth source, benchmark data source, and exact
+  commands. For repository-provided retrieval data, record the Hugging Face dataset
+  `LEANN-RAG/leann-rag-evaluation-data` and the downloaded revision or download date.
+- Backend and index settings, including backend name, compact/recompute mode, `top_k`,
+  `complexity`, BM25/vector weighting, and passage ID scheme.
+- Embedding model, embedding mode, provider options that affect embeddings, and whether embeddings
+  were recomputed during search.
+- Hardware, operating system, Python version, LEANN commit SHA, and whether GPU acceleration was
+  used.
+- Recall@k or hit rate@k where ground truth exists, latency distribution, and local index storage
+  bytes.
+
+Generated JSON/Markdown under `benchmark-results/` stays local or is attached to CI/PR artifacts.
+Commit only curated reports that include the full context above and call out limitations clearly.
+
+A minimal first P0 pack should compare the main supported retrieval path against at least one
+baseline on a real dataset with ground truth. A broader pack should cover HNSW and IVF, include
+BM25/hybrid settings when relevant, and separate retrieval latency from any optional LLM generation.
+Use the single-index retrieval and query-log artifact tools for the first reports, but do not treat
+manual one-off runs as a complete backend comparison; a reviewable cross-backend pack should keep
+dataset, query slice, ground truth, `top_k`, complexity, embedding model, and output schema
+identical across rows.
+
+## Retrieval Evaluation
+
+`benchmarks/run_evaluation.py` is the main retrieval evaluation driver. It can download evaluation
+data when the local `benchmarks/data/` tree is missing required queries, ground truth, or at least
+one real `.index` artifact under `indices/`, and it can reuse a previously downloaded index path
+for larger runs. The repository-provided prebuilt indexes are large, so check local disk capacity
+before relying on the automatic download path; use `--queries-file`, `--ground-truth`, and a
+prebuilt or locally built index path when running a smaller custom pack. Evaluation is
+retrieval-only by default; use `--run-llm` only when generation should be measured separately from
+retrieval latency.
+
+```bash
+uv run benchmarks/run_evaluation.py
+uv run benchmarks/run_evaluation.py benchmarks/data/indices/rpj_wiki/rpj_wiki \
+  --dataset rpj_wiki \
+  --data-source LEANN-RAG/leann-rag-evaluation-data \
+  --data-revision 2026-06-02-download \
+  --num-queries 2000 \
+  --top-k 3 \
+  --complexity 120 \
+  --format markdown \
+  --json-output benchmark-results/retrieval-rpj-wiki.json \
+  --markdown-output benchmark-results/retrieval-rpj-wiki.md
+```
+
+Use this path for recall-oriented comparisons. The JSON artifact records the dataset, data source
+and revision, index path, backend, embedding model/mode, query count, `top_k`, complexity,
+hardware/platform, local LEANN commit, branch, dirty-worktree flag, query-file SHA256 and
+ground-truth-file SHA256 when file paths are available, shell-quoted script command arguments,
+storage bytes, whether embeddings were recomputed, per-query result IDs, per-query golden IDs,
+missing result-ID counts, and duplicate result/golden text counters. Recall is text-overlap based
+for compatibility with indexes that use different passage ID schemes; the duplicate-text counters
+are included so reviewers can identify queries where text-set matching may collapse distinct
+passages. For custom datasets, pass
+`--queries-file`, `--ground-truth`, `--dataset`, `--data-source`, and `--data-revision` explicitly
+so the artifact does not depend on path-name inference.
+
+## Retrieval Backend Comparisons
+
+`benchmarks/compare_retrieval_backends.py` runs the single-index retrieval evaluator across
+multiple prebuilt index paths from one JSON manifest. It is evaluation-only: build or download the
+indexes first, then use the manifest to prove that every row uses the same dataset, query slice,
+ground truth, `top_k`, complexity, and batch size.
+
+Example manifest:
+
+```json
+{
+  "dataset": "rpj_wiki",
+  "data_source": "LEANN-RAG/leann-rag-evaluation-data",
+  "data_revision": "2026-06-02-download",
+  "queries_file": "benchmarks/data/queries/nq_open.jsonl",
+  "ground_truth_file": "benchmarks/data/ground_truth/rpj_wiki/flat_results_nq_k3.json",
+  "num_queries": 2000,
+  "top_k": 3,
+  "complexity": 120,
+  "batch_size": 0,
+  "runs": [
+    {
+      "name": "hnsw",
+      "backend": "hnsw",
+      "index_path": "benchmarks/data/indices/rpj_wiki/rpj_wiki_hnsw"
+    },
+    {
+      "name": "ivf",
+      "backend": "ivf",
+      "index_path": "benchmarks/data/indices/rpj_wiki/rpj_wiki_ivf"
+    }
+  ]
+}
+```
+
+Run it with:
+
+```bash
+uv run python benchmarks/compare_retrieval_backends.py benchmark-results/retrieval-comparison.json \
+  --format markdown \
+  --json-output benchmark-results/retrieval-comparison-summary.json \
+  --markdown-output benchmark-results/retrieval-comparison-summary.md
+```
+
+The combined artifact includes one normalized row per run with backend, passage ID scheme,
+embedding model/mode, recall@k, hit rate@k, evaluated query count, missing ground-truth and golden
+passage counts, missing result-ID counts, duplicate result/golden text counters, latency
+mean/median/p95, storage bytes, local LEANN commit, dirty-worktree flag, and SHA256 hashes for the
+query and ground-truth files. CLI-generated comparison artifacts also record the shell-quoted script
+command arguments. Keep the full per-index evaluation summaries in the JSON artifact for reviewer
+drill-down.
+
+Reviewable benchmark artifacts use one shared timing-statistics helper for mean, median, p95, min,
+and max. p95 is the lower nearest-rank observed sample from the sorted timings, not an interpolated
+value, so retrieval and query-log reports can be compared without reinterpreting the percentile
+rule. The standalone BM25 and DiskANN baseline scripts use the same observed-sample percentile
+helpers for their latency report fields.
+
+## Query Log Summaries
+
+`leann search --query-log <path>` and `leann ask --query-log <path>` write replay-oriented JSONL
+records. New records include `duration_ms`, result IDs, backend settings, and search mode. Use
+`benchmarks/summarize_query_log.py` to turn those logs into reviewable benchmark summaries:
+
+```bash
+uv run python benchmarks/summarize_query_log.py queries.jsonl \
+  --ground-truth ground_truth.json \
+  --index-path .leann/indexes/my-index/documents.leann \
+  --data-source my-dataset \
+  --data-revision 2026-06-02-download \
+  --k 10 \
+  --format markdown \
+  --json-output benchmark-results/my-index-summary.json \
+  --markdown-output benchmark-results/my-index-summary.md
+```
+
+Ground truth can be either a JSON object mapping query text to relevant passage IDs, or JSONL rows
+with `query` plus `relevant_ids`, `gold_ids`, `expected_ids`, or `ids`. The summarizer reports
+recall@k, hit rate@k, result counts, latency mean/median/p95/min/max when present,
+backend/search-mode counts, records with missing result IDs, total missing result IDs,
+missing-latency/backend/search-mode counters, local index storage bytes when index paths are
+available, data source/revision, shell-quoted script command arguments, and local environment
+metadata.
+`--format` controls stdout; `--json-output` and `--markdown-output` optionally write reviewable
+artifacts in the same run. Ground-truth query text must exactly match the `query` value in the
+query log.
+
+Generated benchmark artifacts record the Python script path and arguments with POSIX-style shell
+quoting. Curated reports should still include the full outer shell command, such as `uv run ...`,
+when the wrapper or dependency mode affects reproducibility.
+
+Query logs may contain sensitive query text and, when enabled, query embeddings. Summary artifacts
+omit embeddings and result text, but they still include query counts, backend/search-mode details,
+latency summaries, recall statistics, missing-ID/missing-metadata counters, and storage file paths.
+
+`benchmark-results/` is the default local scratch directory for generated benchmark summaries and
+is gitignored. Commit only curated benchmark reports with enough context to satisfy the reporting
+template below, or attach generated artifacts to a pull request or CI job.
+
+## Benchmark Suites
+
+| Suite | Location | Status | Purpose |
+| --- | --- | --- | --- |
+| BM25 and DiskANN baselines | `benchmarks/bm25_diskann_baselines/` | Data-dependent | Measures Natural Questions search-only latency for BM25 and DiskANN using externally synced artifacts; scripts can write JSON reports with query hashes, timing scope, recursive storage bytes, settings, command arguments, and environment provenance. |
+| ContextBench | `benchmarks/contextbench/` | Manual/agent workflow | Runs repository-preparation and trace-driven code-assistant evaluations. |
+| Enron emails | `benchmarks/enron_emails/` | Data-dependent | Evaluates retrieval and generation on the Enron email corpus. |
+| FinanceBench | `benchmarks/financebench/` | Data-dependent | Evaluates retrieval-augmented generation on financial question answering. |
+| LAION multimodal | `benchmarks/laion/` | Data-dependent and multimodal | Evaluates image retrieval and multimodal generation with CLIP/Qwen-style models. |
+| Update benchmarks | `benchmarks/update/` | Reproducible with local data, hardware-sensitive | Measures update latency and sequential-vs-offline update strategies. |
+
+Historical or sample result files in benchmark subdirectories should be treated as reference runs
+with their documented hardware and settings, not as automatically refreshed results for the current
+checkout.
+
+## Reporting Template
+
+When adding benchmark results, include:
+
+- LEANN commit SHA and backend.
+- Dataset name, corpus size, and query count.
+- Embedding model and embedding mode.
+- Search settings such as `top_k`, `complexity`, `beam_width`, `prune_ratio`, and BM25/vector
+  weighting when applicable.
+- Hardware, operating system, and whether GPU acceleration was used.
+- Build time, index size, search latency distribution, and recall@k where ground truth exists.
+
+This keeps benchmark updates self-contained and reviewable.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,7 +36,7 @@ The primary near-term goal: make LEANN the go-to MCP server for code-aware AI as
 ### Documentation
 
 - [ ] ReadTheDocs — hosted documentation site (#234)
-- [ ] Benchmarks — recall@k, latency, and storage comparisons across backends
+- [ ] Benchmarks — artifact writers and benchmark inventory added; reproducible recall@k, latency, and storage comparisons across real datasets/backends remain
 
 ---
 

--- a/tests/test_benchmark_baselines.py
+++ b/tests/test_benchmark_baselines.py
@@ -1,0 +1,305 @@
+import json
+import subprocess
+import sys
+from hashlib import sha256
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from benchmarks.bm25_diskann_baselines import run_bm25, run_diskann
+from benchmarks.storage import directory_storage
+
+REPO_ROOT = Path(__file__).parent.parent
+BASELINE_DIR = REPO_ROOT / "benchmarks" / "bm25_diskann_baselines"
+
+
+def test_bm25_latency_report_uses_shared_observed_percentiles():
+    report = run_bm25.latency_report(
+        [float(index) for index in range(100)],
+        total_searches=100,
+        total_time=20.0,
+    )
+
+    assert report == {
+        "queries": 100,
+        "avg_s": 49.5,
+        "p50_s": 49.5,
+        "p90_s": 89.0,
+        "p95_s": 94.0,
+        "p99_s": 98.0,
+        "min_s": 0.0,
+        "max_s": 99.0,
+        "total_time_s": 20.0,
+        "qps": 5.0,
+    }
+
+
+def test_bm25_latency_report_handles_empty_latencies():
+    report = run_bm25.latency_report([], total_searches=0, total_time=0.0)
+
+    assert report["avg_s"] == 0.0
+    assert report["p95_s"] == 0.0
+    assert report["qps"] == 0.0
+
+
+def test_bm25_benchmark_report_includes_provenance(tmp_path):
+    queries = tmp_path / "queries.jsonl"
+    queries.write_text('{"query": "alpha"}\n', encoding="utf-8")
+    index_dir = tmp_path / "bm25"
+    index_dir.mkdir()
+    (index_dir / "segments").write_bytes(b"abc")
+    latency = run_bm25.latency_report([1.0, 2.0], total_searches=2, total_time=4.0)
+
+    report = run_bm25.benchmark_report(
+        latency=latency,
+        queries_file=queries,
+        index_dir=index_dir,
+        k=10,
+        k1=0.9,
+        b=0.4,
+        warmup=5,
+        fetch_docs=False,
+        requested_query_count=100,
+        data_source="fixture-source",
+        data_revision="fixture-revision",
+        command="benchmarks/bm25_diskann_baselines/run_bm25.py --report report.json",
+    )
+
+    assert report["schema_version"] == 1
+    assert report["benchmark"] == "bm25_baseline_latency"
+    assert report["data_source"] == "fixture-source"
+    assert report["data_revision"] == "fixture-revision"
+    assert report["command"].startswith("benchmarks/bm25_diskann_baselines/run_bm25.py")
+    assert report["queries_file"] == str(queries)
+    assert report["queries_sha256"] == sha256(queries.read_bytes()).hexdigest()
+    assert report["index_dir"] == str(index_dir.resolve())
+    assert report["storage"] == {
+        "path": str(index_dir.resolve()),
+        "exists": True,
+        "bytes": 3,
+        "file_count": 1,
+    }
+    assert report["query_count"] == 2
+    assert report["requested_query_count"] == 100
+    assert report["timing_scope"] == "search_only"
+    assert report["settings"] == {
+        "k": 10,
+        "k1": 0.9,
+        "b": 0.4,
+        "warmup": 5,
+        "fetch_docs": False,
+    }
+    assert report["latency_s"]["mean"] == 1.5
+    assert report["latency_s"]["min"] == 1.0
+    assert report["latency_s"]["max"] == 2.0
+    assert report["latency_s"]["total"] == 4.0
+    assert "leann_commit" in report["environment"]
+
+
+def test_bm25_write_json_report(tmp_path):
+    report_path = tmp_path / "reports" / "bm25.json"
+
+    run_bm25.write_json_report(report_path, {"schema_version": 1, "benchmark": "bm25"})
+
+    assert json.loads(report_path.read_text(encoding="utf-8")) == {
+        "schema_version": 1,
+        "benchmark": "bm25",
+    }
+
+
+def test_diskann_latency_report_uses_shared_timing_stats():
+    report = run_diskann.latency_report([float(index) for index in range(100)])
+
+    assert report == {
+        "queries": 100,
+        "avg_s": 49.5,
+        "p50_s": 49.5,
+        "p90_s": 89.0,
+        "p95_s": 94.0,
+        "p99_s": 98.0,
+        "min_s": 0.0,
+        "max_s": 99.0,
+        "total_time_s": 4950.0,
+        "qps": 1.0 / 49.5,
+    }
+
+
+def test_diskann_latency_report_handles_empty_latencies():
+    report = run_diskann.latency_report([])
+
+    assert report == {
+        "queries": 0,
+        "avg_s": 0.0,
+        "p50_s": 0.0,
+        "p90_s": 0.0,
+        "p95_s": 0.0,
+        "p99_s": 0.0,
+        "min_s": 0.0,
+        "max_s": 0.0,
+        "total_time_s": 0,
+        "qps": 0.0,
+    }
+
+
+def test_diskann_benchmark_report_includes_provenance(tmp_path):
+    queries = tmp_path / "queries.jsonl"
+    queries.write_text('{"query": "alpha"}\n', encoding="utf-8")
+    index_dir = tmp_path / "diskann"
+    index_dir.mkdir()
+    (index_dir / "ann").write_bytes(b"abc")
+    (index_dir / "ann.tags").write_bytes(b"de")
+    latency = run_diskann.latency_report([1.0, 2.0])
+
+    report = run_diskann.benchmark_report(
+        latency=latency,
+        queries_file=queries,
+        index_dir=index_dir,
+        index_prefix="ann",
+        top_k=10,
+        complexity=62,
+        threads=1,
+        beam_width=1,
+        cache_mechanism=2,
+        num_nodes_to_cache=0,
+        requested_query_count=200,
+        data_source="fixture-source",
+        data_revision="fixture-revision",
+        command="benchmarks/bm25_diskann_baselines/run_diskann.py --report report.json",
+    )
+
+    assert report["schema_version"] == 1
+    assert report["benchmark"] == "diskann_baseline_latency"
+    assert report["data_source"] == "fixture-source"
+    assert report["data_revision"] == "fixture-revision"
+    assert report["command"].startswith("benchmarks/bm25_diskann_baselines/run_diskann.py")
+    assert report["queries_sha256"] == sha256(queries.read_bytes()).hexdigest()
+    assert report["index_dir"] == str(index_dir.resolve())
+    assert report["index_prefix"] == "ann"
+    assert report["index_prefix_path"] == str(index_dir.resolve() / "ann")
+    assert report["storage"] == {
+        "path": str(index_dir.resolve()),
+        "exists": True,
+        "bytes": 5,
+        "file_count": 2,
+    }
+    assert report["query_count"] == 2
+    assert report["requested_query_count"] == 200
+    assert report["embedding_model"] == "facebook/contriever-msmarco"
+    assert report["embedding_in_latency"] is False
+    assert report["timing_scope"] == "search_only"
+    assert report["settings"]["top_k"] == 10
+    assert report["settings"]["complexity"] == 62
+    assert report["settings"]["prune_ratio"] == 0.0
+    assert report["settings"]["recompute_embeddings"] is False
+    assert report["settings"]["batch_recompute"] is False
+    assert report["settings"]["dedup_node_dis"] is False
+    assert report["latency_s"]["mean"] == 1.5
+    assert report["latency_s"]["p90"] == 1.0
+    assert report["latency_s"]["p99"] == 1.0
+    assert report["latency_s"]["total"] == 3.0
+    assert "leann_commit" in report["environment"]
+
+
+def test_diskann_write_json_report(tmp_path):
+    report_path = tmp_path / "reports" / "diskann.json"
+
+    run_diskann.write_json_report(report_path, {"schema_version": 1, "benchmark": "diskann"})
+
+    assert json.loads(report_path.read_text(encoding="utf-8")) == {
+        "schema_version": 1,
+        "benchmark": "diskann",
+    }
+
+
+def test_directory_storage_reports_missing_and_nested_directories(tmp_path):
+    root = tmp_path / "index"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (root / "a").write_bytes(b"abc")
+    (nested / "b").write_bytes(b"de")
+
+    assert directory_storage(root) == {
+        "path": str(root.resolve()),
+        "exists": True,
+        "bytes": 5,
+        "file_count": 2,
+    }
+    assert directory_storage(tmp_path / "missing") == {
+        "path": str((tmp_path / "missing").resolve()),
+        "exists": False,
+        "bytes": 0,
+        "file_count": 0,
+    }
+
+
+def test_directory_storage_reports_empty_existing_directory(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    assert directory_storage(empty) == {
+        "path": str(empty.resolve()),
+        "exists": True,
+        "bytes": 0,
+        "file_count": 0,
+    }
+
+
+def test_baseline_reports_must_not_overwrite_inputs(tmp_path, capsys):
+    queries = tmp_path / "queries.jsonl"
+    queries.write_text('{"query": "alpha"}\n', encoding="utf-8")
+    index_dir = tmp_path / "index"
+    index_dir.mkdir()
+
+    for module, args in (
+        (run_bm25, ["--queries", str(queries), "--report", str(queries)]),
+        (run_diskann, ["--queries-file", str(queries), "--report", str(queries)]),
+        (
+            run_bm25,
+            [
+                "--bm25-index",
+                str(index_dir),
+                "--queries",
+                str(queries),
+                "--report",
+                str(index_dir / "report.json"),
+            ],
+        ),
+        (
+            run_diskann,
+            [
+                "--index-dir",
+                str(index_dir),
+                "--queries-file",
+                str(queries),
+                "--report",
+                str(index_dir / "report.json"),
+            ],
+        ),
+    ):
+        try:
+            module.main(args)
+        except SystemExit as exc:
+            assert exc.code == 2
+        else:
+            raise AssertionError("report path should not overwrite queries")
+
+    captured = capsys.readouterr()
+    assert "report path must not overwrite the queries file" in captured.err
+    assert "report path must not be inside the index directory" in captured.err
+
+
+def test_baseline_scripts_help_from_repo_root_and_subdirectory():
+    for script_name in ("run_bm25.py", "run_diskann.py"):
+        script = BASELINE_DIR / script_name
+        for cwd in (REPO_ROOT, BASELINE_DIR):
+            result = subprocess.run(
+                [sys.executable, str(script), "--help"],
+                cwd=cwd,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0
+            assert "usage:" in result.stdout
+            assert "--report" in result.stdout
+            assert "--data-source" in result.stdout
+            assert "--data-revision" in result.stdout

--- a/tests/test_benchmark_compare_retrieval_backends.py
+++ b/tests/test_benchmark_compare_retrieval_backends.py
@@ -1,0 +1,245 @@
+import json
+import sys
+from hashlib import sha256
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from benchmarks import compare_retrieval_backends
+
+
+class FakePassageManager:
+    def __init__(self):
+        self.passages = {
+            "1": {"text": "alpha document"},
+            "2": {"text": "beta document"},
+        }
+
+    def get_passage(self, passage_id):
+        return self.passages[passage_id]
+
+
+class FakeSearcher:
+    embedding_model = "fake-model"
+    embedding_mode = "sentence-transformers"
+    passage_id_scheme = "content-hash"
+
+    def __init__(self, index_path):
+        self.index_path = str(index_path)
+        self.backend_name = "ivf" if "ivf" in self.index_path else "hnsw"
+        self.passage_manager = FakePassageManager()
+
+    def search(self, query, *, top_k, complexity, batch_size):
+        if self.backend_name == "hnsw":
+            text = "alpha document" if query == "alpha" else "beta document"
+            result_id = "1" if query == "alpha" else "2"
+        elif query == "beta":
+            text = "beta document"
+            result_id = "2"
+        else:
+            text = "miss"
+            result_id = "miss"
+        return [SimpleNamespace(id=result_id, text=text)]
+
+
+def _write_fixture_files(tmp_path):
+    queries_file = tmp_path / "queries.jsonl"
+    queries_file.write_text('{"query": "alpha"}\n{"query": "beta"}\n', encoding="utf-8")
+    ground_truth_file = tmp_path / "truth.json"
+    ground_truth_file.write_text(json.dumps({"indices": [["1"], ["2"]]}), encoding="utf-8")
+    for name in ("hnsw", "ivf"):
+        index_dir = tmp_path / name
+        index_dir.mkdir()
+        (index_dir / "documents.leann.meta.json").write_text("{}", encoding="utf-8")
+        (index_dir / "documents.index").write_bytes(name.encode())
+    return queries_file, ground_truth_file
+
+
+def _manifest(tmp_path):
+    return {
+        "dataset": "fixture",
+        "data_source": "fixture-source",
+        "data_revision": "fixture-revision",
+        "queries_file": "queries.jsonl",
+        "ground_truth_file": "truth.json",
+        "num_queries": 2,
+        "top_k": 1,
+        "complexity": 16,
+        "batch_size": 0,
+        "runs": [
+            {"name": "hnsw", "backend": "hnsw", "index_path": "hnsw/documents.leann"},
+            {"name": "ivf", "backend": "ivf", "index_path": "ivf/documents.leann"},
+        ],
+    }
+
+
+def test_run_comparison_uses_identical_settings_and_normalizes_rows(tmp_path, monkeypatch):
+    queries_file, ground_truth_file = _write_fixture_files(tmp_path)
+    monkeypatch.setattr(compare_retrieval_backends.run_evaluation, "LeannSearcher", FakeSearcher)
+
+    summary = compare_retrieval_backends.run_comparison(_manifest(tmp_path), manifest_dir=tmp_path)
+
+    assert summary["schema_version"] == 1
+    assert summary["benchmark"] == "retrieval_backend_comparison"
+    assert summary["dataset"] == "fixture"
+    assert summary["data_source"] == "fixture-source"
+    assert summary["data_revision"] == "fixture-revision"
+    assert summary["command"] is None
+    assert summary["queries_file"] == str(queries_file)
+    assert summary["ground_truth_file"] == str(ground_truth_file)
+    assert summary["queries_sha256"] == sha256(queries_file.read_bytes()).hexdigest()
+    assert summary["ground_truth_sha256"] == sha256(ground_truth_file.read_bytes()).hexdigest()
+    assert summary["requested_query_count"] == 2
+    assert summary["top_k"] == 1
+    assert summary["complexity"] == 16
+    assert summary["batch_size"] == 0
+    assert summary["run_count"] == 2
+    assert len(summary["evaluations"]) == 2
+
+    hnsw, ivf = summary["runs"]
+    assert hnsw["name"] == "hnsw"
+    assert hnsw["manifest_backend"] == "hnsw"
+    assert hnsw["backend_name"] == "hnsw"
+    assert hnsw["recall_at_k"] == 1.0
+    assert hnsw["hit_rate_at_k"] == 1.0
+    assert hnsw["storage_bytes"] > 0
+    assert hnsw["passage_id_scheme"] == "content-hash"
+    assert hnsw["missing_result_id_count"] == 0
+    assert hnsw["queries_with_duplicate_result_texts"] == 0
+    assert hnsw["queries_with_duplicate_golden_texts"] == 0
+    assert "leann_commit" in hnsw
+    assert ivf["name"] == "ivf"
+    assert ivf["backend_name"] == "ivf"
+    assert ivf["recall_at_k"] == 0.5
+    assert ivf["hit_rate_at_k"] == 0.5
+    assert ivf["missing_result_id_count"] == 0
+    assert ivf["top_k"] == hnsw["top_k"] == 1
+    assert ivf["complexity"] == hnsw["complexity"] == 16
+
+    markdown = compare_retrieval_backends.format_markdown(summary)
+    assert markdown.startswith("# LEANN Retrieval Backend Comparison")
+    assert "Command: unavailable" in markdown
+    assert "Queries SHA256:" in markdown
+    assert "Missing result IDs" in markdown
+    assert "Duplicate result-text queries" in markdown
+    assert "| hnsw | hnsw | content-hash | 1.0000 | 1.0000 | 0 | 0 | 0 |" in markdown
+    assert "| ivf | ivf | content-hash | 0.5000 | 0.5000 | 0 | 0 | 0 |" in markdown
+
+
+def test_comparison_row_preserves_latency_summary():
+    summary = {
+        "recall": {
+            "recall_at_k": 0.75,
+            "hit_rate_at_k": 1.0,
+            "evaluated_queries": 4,
+            "missing_ground_truth_queries": 0,
+            "missing_golden_passages": 0,
+        },
+        "latency_ms": {"mean": 10.0, "median": 9.0, "p95": 14.0, "min": 8.0, "max": 15.0},
+        "storage": {"bytes": 123, "files": ["documents.index"]},
+        "backend_name": "hnsw",
+        "index_path": "documents.leann",
+        "dataset_type": "fixture",
+        "query_count": 4,
+        "requested_query_count": 4,
+        "top_k": 3,
+        "complexity": 64,
+        "batch_size": 0,
+        "embedding_model": "fake-model",
+        "embedding_mode": "sentence-transformers",
+        "passage_id_scheme": "content-hash",
+        "environment": {"leann_commit": "abc123", "leann_dirty": False},
+    }
+
+    row = compare_retrieval_backends._comparison_row({"name": "hnsw"}, summary)
+
+    assert row["latency_ms"] == summary["latency_ms"]
+
+
+def test_main_writes_json_and_markdown_artifacts(tmp_path, monkeypatch, capsys):
+    _write_fixture_files(tmp_path)
+    monkeypatch.setattr(compare_retrieval_backends.run_evaluation, "LeannSearcher", FakeSearcher)
+    manifest_path = tmp_path / "comparison.json"
+    manifest_path.write_text(json.dumps(_manifest(tmp_path)), encoding="utf-8")
+    json_output = tmp_path / "benchmark-results" / "comparison.json"
+    markdown_output = tmp_path / "benchmark-results" / "comparison.md"
+
+    compare_retrieval_backends.main(
+        [
+            str(manifest_path),
+            "--format",
+            "markdown",
+            "--json-output",
+            str(json_output),
+            "--markdown-output",
+            str(markdown_output),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out.startswith("# LEANN Retrieval Backend Comparison")
+    summary = json.loads(json_output.read_text(encoding="utf-8"))
+    assert summary["run_count"] == 2
+    assert summary["runs"][0]["name"] == "hnsw"
+    assert summary["command"].startswith("benchmarks/compare_retrieval_backends.py ")
+    assert summary["evaluations"][0]["command"] is None
+    assert "--json-output" in summary["command"]
+    markdown = markdown_output.read_text(encoding="utf-8")
+    assert markdown.startswith("# LEANN Retrieval Backend Comparison")
+    assert "```bash\nbenchmarks/compare_retrieval_backends.py " in markdown
+
+
+def test_main_rejects_query_or_ground_truth_output_overwrite(tmp_path, monkeypatch, capsys):
+    queries_file, ground_truth_file = _write_fixture_files(tmp_path)
+    monkeypatch.setattr(compare_retrieval_backends.run_evaluation, "LeannSearcher", FakeSearcher)
+    manifest_path = tmp_path / "comparison.json"
+    manifest_path.write_text(json.dumps(_manifest(tmp_path)), encoding="utf-8")
+
+    for args in (
+        [str(manifest_path), "--json-output", str(queries_file)],
+        [str(manifest_path), "--markdown-output", str(ground_truth_file)],
+    ):
+        try:
+            compare_retrieval_backends.main(args)
+        except SystemExit as exc:
+            assert exc.code == 2
+        else:
+            raise AssertionError(f"input overwrite should fail: {args}")
+
+    assert "comparison output path must not overwrite an input file" in capsys.readouterr().err
+
+
+def test_run_comparison_rejects_manifest_backend_mismatch(tmp_path, monkeypatch):
+    _write_fixture_files(tmp_path)
+    monkeypatch.setattr(compare_retrieval_backends.run_evaluation, "LeannSearcher", FakeSearcher)
+    manifest = _manifest(tmp_path)
+    manifest["runs"][1]["backend"] = "hnsw"
+
+    try:
+        compare_retrieval_backends.run_comparison(manifest, manifest_dir=tmp_path)
+    except ValueError as exc:
+        assert "manifest backend for run 'ivf' was 'hnsw' but loaded index reported 'ivf'" in str(
+            exc
+        )
+    else:
+        raise AssertionError("manifest backend mismatches should fail loudly")
+
+
+def test_main_rejects_invalid_manifest_and_output_overwrites(tmp_path, capsys):
+    manifest_path = tmp_path / "comparison.json"
+    manifest_path.write_text(json.dumps({"dataset": "fixture", "runs": []}), encoding="utf-8")
+
+    for args in (
+        [str(manifest_path)],
+        [str(manifest_path), "--json-output", str(manifest_path)],
+    ):
+        try:
+            compare_retrieval_backends.main(args)
+        except SystemExit as exc:
+            assert exc.code == 2
+        else:
+            raise AssertionError(f"invalid args should fail: {args}")
+
+    stderr = capsys.readouterr().err
+    assert "comparison manifest requires non-empty string field: queries_file" in stderr
+    assert "comparison output path must not overwrite an input file" in stderr

--- a/tests/test_benchmark_metrics.py
+++ b/tests/test_benchmark_metrics.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from benchmarks.metrics import mean, observed_percentile, timing_stats
+
+
+def test_mean_returns_zero_for_empty_values():
+    assert mean([]) == 0.0
+
+
+def test_timing_stats_uses_lower_nearest_rank_p95():
+    stats = timing_stats([float(index) for index in range(100)])
+
+    assert stats == {
+        "mean": 49.5,
+        "median": 49.5,
+        "p95": 94.0,
+        "min": 0.0,
+        "max": 99.0,
+    }
+
+
+def test_observed_percentile_returns_measured_sample():
+    values = [float(index) for index in range(100)]
+
+    assert observed_percentile(values, 0) == 0.0
+    assert observed_percentile(values, 90) == 89.0
+    assert observed_percentile(values, 95) == 94.0
+    assert observed_percentile(values, 99) == 98.0
+    assert observed_percentile(values, 100) == 99.0
+
+
+def test_observed_percentile_rejects_out_of_range_percentiles():
+    for percentile in (-1, 101):
+        try:
+            observed_percentile([], percentile)
+        except ValueError as exc:
+            assert "between 0 and 100" in str(exc)
+        else:
+            raise AssertionError(f"invalid percentile should fail: {percentile}")
+
+
+def test_timing_stats_empty_values_are_zeroed():
+    assert timing_stats([]) == {
+        "mean": 0.0,
+        "median": 0.0,
+        "p95": 0.0,
+        "min": 0.0,
+        "max": 0.0,
+    }

--- a/tests/test_benchmark_provenance.py
+++ b/tests/test_benchmark_provenance.py
@@ -1,0 +1,31 @@
+import shlex
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from benchmarks.provenance import benchmark_command
+
+
+def test_benchmark_command_uses_repo_relative_script_path():
+    command = benchmark_command(
+        Path(__file__).parent.parent / "benchmarks" / "run_evaluation.py",
+        ["--dataset", "fixture data"],
+    )
+
+    assert command == "benchmarks/run_evaluation.py --dataset 'fixture data'"
+    assert shlex.split(command) == [
+        "benchmarks/run_evaluation.py",
+        "--dataset",
+        "fixture data",
+    ]
+
+
+def test_benchmark_command_uses_sys_argv_when_argv_is_none(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["ignored.py", "--format", "markdown"])
+
+    command = benchmark_command(
+        Path(__file__).parent.parent / "benchmarks" / "summarize_query_log.py",
+        None,
+    )
+
+    assert command == "benchmarks/summarize_query_log.py --format markdown"

--- a/tests/test_benchmark_query_log_summary.py
+++ b/tests/test_benchmark_query_log_summary.py
@@ -1,0 +1,255 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from benchmarks.summarize_query_log import (
+    format_markdown,
+    format_summary,
+    load_ground_truth,
+    load_query_log,
+    main,
+    summarize_query_log,
+)
+
+
+def test_summarize_query_log_reports_recall_latency_and_storage(tmp_path):
+    query_log = tmp_path / "queries.jsonl"
+    query_log.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "query": "alpha",
+                        "duration_ms": 10.0,
+                        "search_mode": "vector",
+                        "backend_name": "hnsw",
+                        "results": [
+                            {"id": "doc-a", "score": 0.9},
+                            {"id": "doc-b", "score": 0.8},
+                        ],
+                    }
+                ),
+                json.dumps(
+                    {
+                        "query": "beta",
+                        "duration_ms": 20.0,
+                        "search_mode": "hybrid",
+                        "backend_name": "hnsw",
+                        "results": [{"id": "doc-c", "score": 0.7}],
+                    }
+                ),
+                json.dumps(
+                    {
+                        "query": "gamma",
+                        "duration_ms": 100.0,
+                        "results": [{"score": 0.1}],
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    ground_truth = tmp_path / "truth.json"
+    ground_truth.write_text(
+        json.dumps({"alpha": ["doc-a", "doc-z"], "beta": ["doc-x"]}),
+        encoding="utf-8",
+    )
+    index_path = tmp_path / "documents.leann"
+    (tmp_path / "documents.leann.meta.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "documents.leann.passages.idx").write_bytes(b"idx")
+    (tmp_path / "documents.index").write_bytes(b"12345")
+    (tmp_path / "documents2.index").write_bytes(b"not part of this index")
+
+    summary = summarize_query_log(
+        load_query_log(query_log),
+        ground_truth=load_ground_truth(ground_truth),
+        k=1,
+        index_paths=[index_path],
+        data_source="fixture-source",
+        data_revision="fixture-revision",
+    )
+
+    assert summary["schema_version"] == 2
+    assert summary["benchmark"] == "query_log_summary"
+    assert summary["data_source"] == "fixture-source"
+    assert summary["data_revision"] == "fixture-revision"
+    assert summary["command"] is None
+    assert summary["environment"]["python"]
+    assert "leann_commit" in summary["environment"]
+    assert "leann_branch" in summary["environment"]
+    assert "leann_dirty" in summary["environment"]
+    assert summary["query_count"] == 3
+    assert summary["average_result_count"] == 1.0
+    assert summary["records_with_missing_result_ids"] == 1
+    assert summary["missing_result_id_count"] == 1
+    assert summary["records_missing_latency"] == 0
+    assert summary["records_missing_search_mode"] == 1
+    assert summary["records_missing_backend_name"] == 1
+    assert summary["search_modes"] == {"vector": 1, "hybrid": 1, "unknown": 1}
+    assert summary["backends"] == {"hnsw": 2, "unknown": 1}
+    assert summary["latency_ms"]["mean"] == 130.0 / 3.0
+    assert summary["latency_ms"]["p95"] == 20.0
+    assert summary["recall"]["evaluated_queries"] == 2
+    assert summary["recall"]["missing_queries"] == 1
+    assert summary["recall"]["recall_at_k"] == 0.25
+    assert summary["recall"]["hit_rate_at_k"] == 0.5
+    assert summary["storage"]["total_bytes"] == 10
+    assert {Path(path).name for path in summary["storage"]["indexes"][0]["files"]} == {
+        "documents.index",
+        "documents.leann.meta.json",
+        "documents.leann.passages.idx",
+    }
+
+    markdown = format_markdown(summary)
+    assert "Data source: fixture-source" in markdown
+    assert "Data revision: fixture-revision" in markdown
+    assert "Command: unavailable" in markdown
+    assert "Recall@1: 0.250" in markdown
+    assert "Latency ms: mean=43.333, median=20.000, p95=20.000" in markdown
+    assert "Records with missing result IDs: 1" in markdown
+    assert "Missing result ID count: 1" in markdown
+    assert "Records missing backend name: 1" in markdown
+
+
+def test_load_ground_truth_accepts_jsonl_rows(tmp_path):
+    path = tmp_path / "truth.jsonl"
+    path.write_text(
+        json.dumps({"query": "alpha", "relevant_ids": ["doc-a"]}) + "\n",
+        encoding="utf-8",
+    )
+
+    assert load_ground_truth(path) == {"alpha": {"doc-a"}}
+
+
+def test_format_summary_rejects_unknown_format():
+    try:
+        format_summary({"query_count": 0}, "html")
+    except ValueError as exc:
+        assert "unsupported output format" in str(exc)
+    else:
+        raise AssertionError("unknown summary formats should fail clearly")
+
+
+def test_summarize_query_log_reports_empty_ground_truth_explicitly():
+    summary = summarize_query_log([{"query": "alpha", "results": []}], ground_truth={}, k=1)
+
+    assert summary["recall"] == {
+        "evaluated_queries": 0,
+        "missing_queries": 1,
+        "recall_at_k": 0.0,
+        "hit_rate_at_k": 0.0,
+    }
+
+
+def test_summarize_query_log_distinguishes_empty_results_from_missing_ids():
+    summary = summarize_query_log(
+        [
+            {"query": "empty", "results": []},
+            {"query": "partial", "results": [{"id": "doc-a"}, {"score": 0.1}]},
+            {"query": "bad", "results": {"id": "doc-b"}},
+            {"query": "absent"},
+        ],
+        k=1,
+    )
+
+    assert summary["query_count"] == 4
+    assert summary["average_result_count"] == 0.25
+    assert summary["records_with_missing_result_ids"] == 2
+    assert summary["missing_result_id_count"] == 2
+
+
+def test_summarize_query_log_p95_uses_lower_nearest_rank_sample():
+    records = [
+        {"query": f"q-{index}", "duration_ms": float(index), "results": []} for index in range(100)
+    ]
+
+    summary = summarize_query_log(records, k=1)
+
+    assert summary["latency_ms"]["p95"] == 94.0
+
+
+def test_main_writes_json_and_markdown_artifacts_while_preserving_stdout(tmp_path, capsys):
+    query_log = tmp_path / "queries.jsonl"
+    query_log.write_text(
+        json.dumps(
+            {
+                "query": "alpha",
+                "duration_ms": 12.0,
+                "search_mode": "vector",
+                "backend_name": "hnsw",
+                "results": [{"id": "doc-a", "score": 0.9}],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    json_output = tmp_path / "artifacts" / "summary.json"
+    markdown_output = tmp_path / "artifacts" / "summary.md"
+
+    main(
+        [
+            str(query_log),
+            "--format",
+            "markdown",
+            "--data-source",
+            "fixture-source",
+            "--data-revision",
+            "fixture-revision",
+            "--json-output",
+            str(json_output),
+            "--markdown-output",
+            str(markdown_output),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out.startswith("# LEANN Query Log Summary")
+    summary = json.loads(json_output.read_text(encoding="utf-8"))
+    assert summary["query_count"] == 1
+    assert summary["data_source"] == "fixture-source"
+    assert summary["data_revision"] == "fixture-revision"
+    assert summary["command"].startswith("benchmarks/summarize_query_log.py ")
+    assert "--data-source fixture-source" in summary["command"]
+    markdown = markdown_output.read_text(encoding="utf-8")
+    assert markdown.startswith("# LEANN Query Log Summary")
+    assert "```bash\nbenchmarks/summarize_query_log.py " in markdown
+    assert "Queries: 1" in markdown
+
+
+def test_main_rejects_invalid_k_and_query_log_overwrite(tmp_path, capsys):
+    query_log = tmp_path / "queries.jsonl"
+    query_log.write_text('{"query": "alpha", "results": []}\n', encoding="utf-8")
+    ground_truth = tmp_path / "truth.json"
+    ground_truth.write_text(json.dumps({"alpha": ["doc-a"]}), encoding="utf-8")
+
+    for args in (
+        [str(query_log), "--k", "0"],
+        [str(query_log), "--json-output", str(query_log)],
+        [
+            str(query_log),
+            "--ground-truth",
+            str(ground_truth),
+            "--markdown-output",
+            str(ground_truth),
+        ],
+        [
+            str(query_log),
+            "--json-output",
+            str(tmp_path / "same"),
+            "--markdown-output",
+            str(tmp_path / "same"),
+        ],
+    ):
+        try:
+            main(args)
+        except SystemExit as exc:
+            assert exc.code == 2
+        else:
+            raise AssertionError(f"invalid args should fail: {args}")
+
+    captured = capsys.readouterr()
+    assert "--k must be greater than 0" in captured.err
+    assert "must not overwrite an input file" in captured.err
+    assert "JSON and Markdown output paths must be different" in captured.err

--- a/tests/test_benchmark_run_evaluation.py
+++ b/tests/test_benchmark_run_evaluation.py
@@ -172,7 +172,7 @@ def test_run_retrieval_evaluation_leaves_hashes_unset_for_in_memory_inputs(tmp_p
     assert "Ground truth SHA256: `unavailable`" in markdown
 
 
-def test_run_retrieval_evaluation_p95_matches_shared_timing_rule(tmp_path):
+def test_run_retrieval_evaluation_p95_matches_shared_timing_rule(tmp_path, monkeypatch):
     class SequencedSearcher(FakeSearcher):
         def search(self, query, *, top_k, complexity, batch_size):
             return [SimpleNamespace(id=str(query), text=f"doc-{query}")]
@@ -184,25 +184,25 @@ def test_run_retrieval_evaluation_p95_matches_shared_timing_rule(tmp_path):
         {str(index): {"text": f"doc-{index}"} for index in range(100)}
     )
 
-    original_perf_counter = run_evaluation.time.perf_counter
     ticks = iter(timestamp for index in range(100) for timestamp in (0.0, float(index) / 1000.0))
-    run_evaluation.time.perf_counter = lambda: next(ticks)
-    try:
-        summary = run_retrieval_evaluation(
-            searcher,
-            queries,
-            golden_results,
-            index_path=str(tmp_path / "documents.leann"),
-            dataset_type="fixture",
-            queries_file="memory://queries",
-            ground_truth_file="memory://truth",
-            num_queries=100,
-            top_k=1,
-            complexity=16,
-            batch_size=0,
-        )
-    finally:
-        run_evaluation.time.perf_counter = original_perf_counter
+
+    def fake_perf_counter() -> float:
+        return next(ticks)
+
+    monkeypatch.setattr(run_evaluation.time, "perf_counter", fake_perf_counter)
+    summary = run_retrieval_evaluation(
+        searcher,
+        queries,
+        golden_results,
+        index_path=str(tmp_path / "documents.leann"),
+        dataset_type="fixture",
+        queries_file="memory://queries",
+        ground_truth_file="memory://truth",
+        num_queries=100,
+        top_k=1,
+        complexity=16,
+        batch_size=0,
+    )
 
     assert summary["latency_ms"]["p95"] == 94.0
 

--- a/tests/test_benchmark_run_evaluation.py
+++ b/tests/test_benchmark_run_evaluation.py
@@ -1,0 +1,444 @@
+import json
+import sys
+from hashlib import sha256
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from benchmarks import run_evaluation
+from benchmarks.run_evaluation import (
+    format_markdown,
+    format_summary,
+    load_queries,
+    main,
+    run_retrieval_evaluation,
+)
+
+
+class FakePassageManager:
+    def __init__(self, passages):
+        self.passages = passages
+
+    def get_passage(self, passage_id):
+        return self.passages[passage_id]
+
+
+class FakeSearcher:
+    backend_name = "hnsw"
+    embedding_model = "fake-model"
+    embedding_mode = "sentence-transformers"
+    passage_id_scheme = "content-hash"
+
+    def __init__(self):
+        self.passage_manager = FakePassageManager(
+            {
+                "1": {"text": "alpha document"},
+                "2": {"text": "beta document"},
+                "3": {"text": "gamma document"},
+                "4": {"text": "gamma document"},
+            }
+        )
+        self.calls = []
+
+    def search(self, query, *, top_k, complexity, batch_size):
+        self.calls.append(
+            {
+                "query": query,
+                "top_k": top_k,
+                "complexity": complexity,
+                "batch_size": batch_size,
+            }
+        )
+        if query == "alpha":
+            return [
+                SimpleNamespace(id="1", text="alpha document"),
+                SimpleNamespace(id="x", text="unrelated document"),
+            ]
+        if query == "beta":
+            return [
+                SimpleNamespace(id="miss-1", text="miss"),
+                SimpleNamespace(text="miss"),
+            ]
+        return [
+            SimpleNamespace(id="3", text="gamma document"),
+            SimpleNamespace(id="3-copy", text="gamma document"),
+        ]
+
+
+def test_run_retrieval_evaluation_reports_recall_latency_storage(tmp_path):
+    queries_file = tmp_path / "queries.jsonl"
+    queries_file.write_text('{"query": "alpha"}\n{"query": "beta"}\n', encoding="utf-8")
+    ground_truth_file = tmp_path / "truth.json"
+    ground_truth_file.write_text(
+        json.dumps({"indices": [["1", "2"], ["3", "4"]]}), encoding="utf-8"
+    )
+    index_path = tmp_path / "documents.leann"
+    (tmp_path / "documents.leann.meta.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "documents.leann.passages.idx").write_bytes(b"idx")
+    (tmp_path / "documents.index").write_bytes(b"12345")
+    (tmp_path / "other.index").write_bytes(b"not part of this index")
+
+    summary = run_retrieval_evaluation(
+        FakeSearcher(),
+        ["alpha", "beta", "missing-ground-truth"],
+        {"indices": [["1", "2"], ["3", "4"]]},
+        index_path=str(index_path),
+        dataset_type="fixture",
+        queries_file=queries_file,
+        ground_truth_file=ground_truth_file,
+        num_queries=3,
+        top_k=2,
+        complexity=64,
+        batch_size=0,
+        data_source="fixture-source",
+        data_revision="fixture-revision",
+        queries_sha256=sha256(queries_file.read_bytes()).hexdigest(),
+        ground_truth_sha256=sha256(ground_truth_file.read_bytes()).hexdigest(),
+    )
+
+    assert summary["schema_version"] == 2
+    assert summary["benchmark"] == "retrieval_evaluation"
+    assert summary["mode"] == "retrieval_only"
+    assert summary["llm_used"] is False
+    assert summary["data_source"] == "fixture-source"
+    assert summary["data_revision"] == "fixture-revision"
+    assert summary["command"] is None
+    assert summary["queries_file"] == str(queries_file)
+    assert summary["queries_sha256"] == sha256(queries_file.read_bytes()).hexdigest()
+    assert summary["ground_truth_file"] == str(ground_truth_file)
+    assert summary["ground_truth_sha256"] == sha256(ground_truth_file.read_bytes()).hexdigest()
+    assert summary["environment"]["python"]
+    assert "platform" in summary["environment"]
+    assert "leann_commit" in summary["environment"]
+    assert "leann_branch" in summary["environment"]
+    assert "leann_dirty" in summary["environment"]
+    assert summary["backend_name"] == "hnsw"
+    assert summary["query_count"] == 3
+    assert summary["recall"]["evaluated_queries"] == 2
+    assert summary["recall"]["missing_ground_truth_queries"] == 1
+    assert summary["recall"]["recall_at_k"] == 0.25
+    assert summary["recall"]["hit_rate_at_k"] == 0.5
+    assert summary["recall"]["queries_with_missing_result_ids"] == 1
+    assert summary["recall"]["missing_result_id_count"] == 1
+    assert summary["recall"]["queries_with_duplicate_result_texts"] == 2
+    assert summary["recall"]["queries_with_duplicate_golden_texts"] == 1
+    assert summary["average_result_count"] == 2.0
+    assert summary["latency_ms"]["median"] >= 0.0
+    assert summary["storage"]["bytes"] == 10
+    assert {Path(path).name for path in summary["storage"]["files"]} == {
+        "documents.index",
+        "documents.leann.meta.json",
+        "documents.leann.passages.idx",
+    }
+    assert summary["per_query"][0]["result_ids"] == ["1", "x"]
+    assert summary["per_query"][0]["golden_ids"] == ["1", "2"]
+    assert summary["per_query"][1]["result_ids"] == ["miss-1"]
+    assert summary["per_query"][1]["missing_result_id_count"] == 1
+    assert summary["per_query"][1]["golden_duplicate_text_count"] == 1
+    assert summary["per_query"][2]["result_duplicate_text_count"] == 1
+
+    markdown = format_markdown(summary)
+    assert markdown.startswith("# LEANN Retrieval Evaluation")
+    assert "Data source: fixture-source" in markdown
+    assert "Data revision: fixture-revision" in markdown
+    assert "Command: unavailable" in markdown
+    assert "Queries SHA256:" in markdown
+    assert "Ground truth SHA256:" in markdown
+    assert "Recall@2: 0.2500" in markdown
+    assert "Queries with missing result IDs: 1" in markdown
+    assert "Queries with duplicate golden text: 1" in markdown
+    assert json.loads(format_summary(summary, "json"))["dataset_type"] == "fixture"
+
+
+def test_run_retrieval_evaluation_leaves_hashes_unset_for_in_memory_inputs(tmp_path):
+    summary = run_retrieval_evaluation(
+        FakeSearcher(),
+        ["alpha"],
+        {"indices": [["1"]]},
+        index_path=str(tmp_path / "documents.leann"),
+        dataset_type="fixture",
+        queries_file="memory://queries",
+        ground_truth_file="memory://truth",
+        num_queries=1,
+        top_k=1,
+        complexity=16,
+        batch_size=0,
+    )
+
+    assert summary["queries_sha256"] is None
+    assert summary["ground_truth_sha256"] is None
+    markdown = format_markdown(summary)
+    assert "Queries SHA256: `unavailable`" in markdown
+    assert "Ground truth SHA256: `unavailable`" in markdown
+
+
+def test_run_retrieval_evaluation_p95_matches_shared_timing_rule(tmp_path):
+    class SequencedSearcher(FakeSearcher):
+        def search(self, query, *, top_k, complexity, batch_size):
+            return [SimpleNamespace(id=str(query), text=f"doc-{query}")]
+
+    queries = [str(index) for index in range(100)]
+    golden_results = {"indices": [[str(index)] for index in range(100)]}
+    searcher = SequencedSearcher()
+    searcher.passage_manager = FakePassageManager(
+        {str(index): {"text": f"doc-{index}"} for index in range(100)}
+    )
+
+    original_perf_counter = run_evaluation.time.perf_counter
+    ticks = iter(timestamp for index in range(100) for timestamp in (0.0, float(index) / 1000.0))
+    run_evaluation.time.perf_counter = lambda: next(ticks)
+    try:
+        summary = run_retrieval_evaluation(
+            searcher,
+            queries,
+            golden_results,
+            index_path=str(tmp_path / "documents.leann"),
+            dataset_type="fixture",
+            queries_file="memory://queries",
+            ground_truth_file="memory://truth",
+            num_queries=100,
+            top_k=1,
+            complexity=16,
+            batch_size=0,
+        )
+    finally:
+        run_evaluation.time.perf_counter = original_perf_counter
+
+    assert summary["latency_ms"]["p95"] == 94.0
+
+
+def test_load_queries_skips_blank_lines_and_requires_query(tmp_path):
+    queries_file = tmp_path / "queries.jsonl"
+    queries_file.write_text('{"query": "alpha"}\n\n{"query": "beta"}\n', encoding="utf-8")
+    assert load_queries(queries_file) == ["alpha", "beta"]
+
+    bad_file = tmp_path / "bad.jsonl"
+    bad_file.write_text('{"question": "alpha"}\n', encoding="utf-8")
+    try:
+        load_queries(bad_file)
+    except ValueError as exc:
+        assert "missing string query" in str(exc)
+    else:
+        raise AssertionError("query rows without query should fail clearly")
+
+
+def test_download_data_if_needed_refreshes_incomplete_data_root(tmp_path, monkeypatch, capsys):
+    data_root = tmp_path / "data"
+    data_root.mkdir()
+    (data_root / "README.md").write_text("metadata only", encoding="utf-8")
+    calls = []
+
+    def fake_snapshot_download(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(snapshot_download=fake_snapshot_download),
+    )
+
+    run_evaluation.download_data_if_needed(data_root)
+
+    assert len(calls) == 1
+    assert calls[0]["repo_id"] == "LEANN-RAG/leann-rag-evaluation-data"
+    assert calls[0]["repo_type"] == "dataset"
+    assert calls[0]["local_dir"] == data_root
+    assert "indices/**" in calls[0]["allow_patterns"]
+    assert "queries/**" in calls[0]["allow_patterns"]
+    assert "ground_truth/**" in calls[0]["allow_patterns"]
+    assert "is incomplete" in capsys.readouterr().out
+
+
+def test_download_data_if_needed_skips_complete_data_root(tmp_path, monkeypatch):
+    data_root = tmp_path / "data"
+    (data_root / "queries").mkdir(parents=True)
+    (data_root / "queries" / "nq_open.jsonl").write_text('{"query": "alpha"}\n')
+    (data_root / "ground_truth").mkdir()
+    (data_root / "indices" / "dpr").mkdir(parents=True)
+    (data_root / "indices" / "dpr" / "dpr.index").write_bytes(b"index")
+
+    def fail_snapshot_download(**kwargs):
+        raise AssertionError("complete evaluation data should not be downloaded")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(snapshot_download=fail_snapshot_download),
+    )
+
+    run_evaluation.download_data_if_needed(data_root)
+
+
+def test_download_data_if_needed_refreshes_empty_indices(tmp_path, monkeypatch, capsys):
+    data_root = tmp_path / "data"
+    (data_root / "queries").mkdir(parents=True)
+    (data_root / "queries" / "nq_open.jsonl").write_text('{"query": "alpha"}\n')
+    (data_root / "ground_truth").mkdir()
+    (data_root / "indices").mkdir()
+    calls = []
+
+    def fake_snapshot_download(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(snapshot_download=fake_snapshot_download),
+    )
+
+    run_evaluation.download_data_if_needed(data_root)
+
+    assert len(calls) == 1
+    assert "indices/**" in calls[0]["allow_patterns"]
+    assert "is incomplete" in capsys.readouterr().out
+
+
+def test_download_data_if_needed_refreshes_artifact_free_indices(tmp_path, monkeypatch, capsys):
+    data_root = tmp_path / "data"
+    (data_root / "queries").mkdir(parents=True)
+    (data_root / "queries" / "nq_open.jsonl").write_text('{"query": "alpha"}\n')
+    (data_root / "ground_truth").mkdir()
+    (data_root / "indices" / "dpr").mkdir(parents=True)
+    (data_root / "indices" / "dpr" / "README.md").write_text("metadata only", encoding="utf-8")
+    calls = []
+
+    def fake_snapshot_download(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(snapshot_download=fake_snapshot_download),
+    )
+
+    run_evaluation.download_data_if_needed(data_root)
+
+    assert len(calls) == 1
+    assert "indices/**" in calls[0]["allow_patterns"]
+    assert "is incomplete" in capsys.readouterr().out
+
+
+def test_main_writes_artifacts_and_does_not_run_llm_by_default(tmp_path, monkeypatch, capsys):
+    queries_file = tmp_path / "queries.jsonl"
+    queries_file.write_text('{"query": "alpha"}\n', encoding="utf-8")
+    ground_truth_file = tmp_path / "truth.json"
+    ground_truth_file.write_text(json.dumps({"indices": [["1"]]}), encoding="utf-8")
+    index_path = tmp_path / "documents.leann"
+    (tmp_path / "documents.leann.meta.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(run_evaluation, "download_data_if_needed", lambda *args, **kwargs: None)
+    monkeypatch.setattr(run_evaluation, "LeannSearcher", lambda index_path: FakeSearcher())
+
+    def fail_chat(*args, **kwargs):
+        raise AssertionError("LeannChat must be opt-in for retrieval-only evaluation")
+
+    monkeypatch.setattr(run_evaluation, "LeannChat", fail_chat)
+    json_output = tmp_path / "benchmark-results" / "retrieval.json"
+    markdown_output = tmp_path / "benchmark-results" / "retrieval.md"
+
+    main(
+        [
+            str(index_path),
+            "--dataset",
+            "fixture",
+            "--queries-file",
+            str(queries_file),
+            "--ground-truth",
+            str(ground_truth_file),
+            "--num-queries",
+            "1",
+            "--top-k",
+            "1",
+            "--complexity",
+            "16",
+            "--data-source",
+            "fixture-source",
+            "--data-revision",
+            "fixture-revision",
+            "--format",
+            "markdown",
+            "--json-output",
+            str(json_output),
+            "--markdown-output",
+            str(markdown_output),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out.startswith("INFO: Detected dataset type: fixture")
+    assert "# LEANN Retrieval Evaluation" in captured.out
+    summary = json.loads(json_output.read_text(encoding="utf-8"))
+    assert summary["llm_used"] is False
+    assert summary["data_source"] == "fixture-source"
+    assert summary["data_revision"] == "fixture-revision"
+    assert summary["command"].startswith("benchmarks/run_evaluation.py ")
+    assert "--data-source fixture-source" in summary["command"]
+    markdown = markdown_output.read_text(encoding="utf-8")
+    assert "```bash\nbenchmarks/run_evaluation.py " in markdown
+    assert summary["queries_sha256"] == sha256(queries_file.read_bytes()).hexdigest()
+    assert summary["ground_truth_sha256"] == sha256(ground_truth_file.read_bytes()).hexdigest()
+    assert markdown.startswith("# LEANN Retrieval Evaluation")
+
+
+def test_main_rejects_invalid_args_and_output_overwrites(tmp_path, monkeypatch, capsys):
+    queries_file = tmp_path / "queries.jsonl"
+    queries_file.write_text('{"query": "alpha"}\n', encoding="utf-8")
+    ground_truth_file = tmp_path / "truth.json"
+    ground_truth_file.write_text(json.dumps({"indices": [["1"]]}), encoding="utf-8")
+    monkeypatch.setattr(run_evaluation, "download_data_if_needed", lambda *args, **kwargs: None)
+
+    for args in (
+        ["index", "--num-queries", "0"],
+        ["index", "--top-k", "0"],
+        ["index", "--complexity", "0"],
+        ["index", "--batch-size", "-1"],
+        [
+            "index",
+            "--queries-file",
+            str(queries_file),
+            "--ground-truth",
+            str(ground_truth_file),
+            "--json-output",
+            str(queries_file),
+        ],
+    ):
+        try:
+            main(args)
+        except SystemExit as exc:
+            assert exc.code == 2
+        else:
+            raise AssertionError(f"invalid args should fail: {args}")
+
+    captured = capsys.readouterr()
+    assert "--num-queries must be greater than 0" in captured.err
+    assert "--top-k must be greater than 0" in captured.err
+    assert "--complexity must be greater than 0" in captured.err
+    assert "--batch-size must be greater than or equal to 0" in captured.err
+    assert "summary output path must not overwrite an input file" in captured.err
+
+
+def test_main_rejects_empty_queries_file(tmp_path, monkeypatch, capsys):
+    queries_file = tmp_path / "queries.jsonl"
+    queries_file.write_text("\n", encoding="utf-8")
+    ground_truth_file = tmp_path / "truth.json"
+    ground_truth_file.write_text(json.dumps({"indices": []}), encoding="utf-8")
+
+    monkeypatch.setattr(run_evaluation, "download_data_if_needed", lambda *args, **kwargs: None)
+    monkeypatch.setattr(run_evaluation, "LeannSearcher", lambda index_path: FakeSearcher())
+
+    try:
+        main(
+            [
+                "index",
+                "--queries-file",
+                str(queries_file),
+                "--ground-truth",
+                str(ground_truth_file),
+            ]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("empty query files should fail clearly")
+
+    assert "queries file did not contain any queries" in capsys.readouterr().err

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -9,15 +9,80 @@ from pathlib import Path
 
 import pytest
 
+CI_EMBEDDING_DIMENSIONS = 4
+
+
+def _is_ci() -> bool:
+    return os.environ.get("CI") == "true"
+
+
+def _install_ci_embeddings(monkeypatch):
+    """Use deterministic embeddings in CI so docs tests do not depend on model downloads."""
+    if not _is_ci():
+        return
+
+    import leann.api as leann_api
+    import leann.embedding_compute as embedding_compute
+    import numpy as np
+
+    def fake_compute_embeddings(
+        chunks,
+        model_name,
+        mode="sentence-transformers",
+        use_server=True,
+        port=None,
+        is_build=False,
+        provider_options=None,
+    ):
+        del model_name, mode, use_server, port, is_build, provider_options
+        embeddings = []
+        for chunk in chunks:
+            text = str(chunk).lower()
+            if (
+                "fantastical" in text
+                or "ai-generated" in text
+                or "banana" in text
+                or "crocodile" in text
+            ):
+                embeddings.append([1.0, 0.0, 0.0, 0.0])
+            elif "storage" in text or "97%" in text or "saves" in text:
+                embeddings.append([0.0, 1.0, 0.0, 0.0])
+            elif "llm" in text or "testing" in text:
+                embeddings.append([0.0, 0.0, 1.0, 0.0])
+            else:
+                embeddings.append([0.0, 0.0, 0.0, 1.0])
+        return np.asarray(embeddings, dtype=np.float32)
+
+    monkeypatch.setattr(leann_api, "compute_embeddings", fake_compute_embeddings)
+    monkeypatch.setattr(embedding_compute, "compute_embeddings", fake_compute_embeddings)
+
+
+def _ci_builder_kwargs() -> dict:
+    if not _is_ci():
+        return {}
+    return {
+        "embedding_model": "ci/deterministic-test-embedding",
+        "dimensions": CI_EMBEDDING_DIMENSIONS,
+        "is_compact": False,
+        "is_recompute": False,
+    }
+
+
+def _ci_searcher_kwargs() -> dict:
+    if not _is_ci():
+        return {}
+    return {"enable_warmup": False, "recompute_embeddings": False}
+
 
 @pytest.mark.parametrize("backend_name", ["hnsw", "diskann"])
-def test_readme_basic_example(backend_name):
+def test_readme_basic_example(backend_name, monkeypatch):
     """Test the basic example from README.md with both backends."""
+    _install_ci_embeddings(monkeypatch)
     # Skip on macOS CI due to MPS environment issues with all-MiniLM-L6-v2
-    if os.environ.get("CI") == "true" and platform.system() == "Darwin":
+    if _is_ci() and platform.system() == "Darwin":
         pytest.skip("Skipping on macOS CI due to MPS environment issues with all-MiniLM-L6-v2")
     # Skip DiskANN on CI (Linux runners) due to C++ extension memory/hardware constraints
-    if os.environ.get("CI") == "true" and backend_name == "diskann":
+    if _is_ci() and backend_name == "diskann":
         pytest.skip("Skip DiskANN tests in CI due to resource constraints and instability")
 
     # This is the exact code from README (with smaller model for CI)
@@ -27,11 +92,10 @@ def test_readme_basic_example(backend_name):
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         INDEX_PATH = str(Path(temp_dir) / f"demo_{backend_name}.leann")
 
-        if os.environ.get("CI") == "true":
+        if _is_ci():
             builder = LeannBuilder(
                 backend_name=backend_name,
-                embedding_model="sentence-transformers/all-MiniLM-L6-v2",
-                dimensions=384,
+                **_ci_builder_kwargs(),
             )
         else:
             builder = LeannBuilder(backend_name=backend_name)
@@ -44,8 +108,11 @@ def test_readme_basic_example(backend_name):
         index_files = list(index_dir.glob(f"{Path(INDEX_PATH).stem}.*"))
         assert len(index_files) > 0
 
-        with LeannSearcher(INDEX_PATH) as searcher:
-            results = searcher.search("fantastical AI-generated creatures", top_k=1)
+        with LeannSearcher(INDEX_PATH, **_ci_searcher_kwargs()) as searcher:
+            results = searcher.search(
+                "fantastical AI-generated creatures",
+                top_k=1,
+            )
 
             assert len(results) > 0
             assert isinstance(results[0], SearchResult)
@@ -54,8 +121,16 @@ def test_readme_basic_example(backend_name):
             )
             assert "banana" in results[0].text or "crocodile" in results[0].text
 
-        chat = LeannChat(INDEX_PATH, llm_config={"type": "simulated"})
-        response = chat.ask("How much storage does LEANN save?", top_k=1)
+        chat = LeannChat(
+            INDEX_PATH,
+            llm_config={"type": "simulated"},
+            **_ci_searcher_kwargs(),
+        )
+        response = chat.ask(
+            "How much storage does LEANN save?",
+            top_k=1,
+            recompute_embeddings=not _is_ci(),
+        )
 
         # Verify chat works
         assert isinstance(response, str)
@@ -75,31 +150,33 @@ def test_readme_imports():
     assert callable(LeannChat)
 
 
-def test_backend_options():
+def test_backend_options(monkeypatch):
     """Test different backend options mentioned in documentation."""
+    _install_ci_embeddings(monkeypatch)
     # Skip on macOS CI due to MPS environment issues with all-MiniLM-L6-v2
-    if os.environ.get("CI") == "true" and platform.system() == "Darwin":
+    if _is_ci() and platform.system() == "Darwin":
         pytest.skip("Skipping on macOS CI due to MPS environment issues with all-MiniLM-L6-v2")
 
     from leann import LeannBuilder
 
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
-        is_ci = os.environ.get("CI") == "true"
-        embedding_model = (
-            "sentence-transformers/all-MiniLM-L6-v2" if is_ci else "facebook/contriever"
-        )
-        dimensions = 384 if is_ci else None
-
         hnsw_path = str(Path(temp_dir) / "test_hnsw.leann")
-        builder_hnsw = LeannBuilder(
-            backend_name="hnsw", embedding_model=embedding_model, dimensions=dimensions
-        )
+        if _is_ci():
+            builder_hnsw = LeannBuilder(
+                backend_name="hnsw",
+                **_ci_builder_kwargs(),
+            )
+        else:
+            builder_hnsw = LeannBuilder(
+                backend_name="hnsw",
+                embedding_model="facebook/contriever",
+            )
         builder_hnsw.add_text("Test document for HNSW backend")
         builder_hnsw.build_index(hnsw_path)
         assert Path(hnsw_path).parent.exists()
         assert len(list(Path(hnsw_path).parent.glob(f"{Path(hnsw_path).stem}.*"))) > 0
 
-        if is_ci:
+        if _is_ci():
             pytest.skip(
                 "Skip DiskANN portion in CI - small datasets trigger MKL parameter "
                 "errors and pytest-timeout thread kills cause segfaults on Windows"
@@ -107,7 +184,8 @@ def test_backend_options():
 
         diskann_path = str(Path(temp_dir) / "test_diskann.leann")
         builder_diskann = LeannBuilder(
-            backend_name="diskann", embedding_model=embedding_model, dimensions=dimensions
+            backend_name="diskann",
+            embedding_model="facebook/contriever",
         )
         builder_diskann.add_text("Test document for DiskANN backend")
         builder_diskann.build_index(diskann_path)
@@ -116,25 +194,25 @@ def test_backend_options():
 
 
 @pytest.mark.parametrize("backend_name", ["hnsw", "diskann"])
-def test_llm_config_simulated(backend_name):
+def test_llm_config_simulated(backend_name, monkeypatch):
     """Test simulated LLM configuration option with both backends."""
+    _install_ci_embeddings(monkeypatch)
     # Skip on macOS CI due to MPS environment issues with all-MiniLM-L6-v2
-    if os.environ.get("CI") == "true" and platform.system() == "Darwin":
+    if _is_ci() and platform.system() == "Darwin":
         pytest.skip("Skipping on macOS CI due to MPS environment issues with all-MiniLM-L6-v2")
 
     # Skip DiskANN tests in CI due to hardware requirements
-    if os.environ.get("CI") == "true" and backend_name == "diskann":
+    if _is_ci() and backend_name == "diskann":
         pytest.skip("Skip DiskANN tests in CI - requires specific hardware and large memory")
 
     from leann import LeannBuilder, LeannChat
 
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         index_path = str(Path(temp_dir) / f"test_{backend_name}.leann")
-        if os.environ.get("CI") == "true":
+        if _is_ci():
             builder = LeannBuilder(
                 backend_name=backend_name,
-                embedding_model="sentence-transformers/all-MiniLM-L6-v2",
-                dimensions=384,
+                **_ci_builder_kwargs(),
             )
         else:
             builder = LeannBuilder(backend_name=backend_name)
@@ -142,8 +220,12 @@ def test_llm_config_simulated(backend_name):
         builder.build_index(index_path)
 
         llm_config = {"type": "simulated"}
-        chat = LeannChat(index_path, llm_config=llm_config)
-        response = chat.ask("What is this document about?", top_k=1)
+        chat = LeannChat(index_path, llm_config=llm_config, **_ci_searcher_kwargs())
+        response = chat.ask(
+            "What is this document about?",
+            top_k=1,
+            recompute_embeddings=not _is_ci(),
+        )
 
         assert isinstance(response, str)
         assert len(response) > 0


### PR DESCRIPTION
## Evaluator Summary

- Abi added reproducible benchmark artifact tooling for recall, latency, storage, provenance, query-log summaries, and backend comparisons, moving LEANN evaluation from ad hoc scripts toward auditable reports.
- The design records input hashes, timing/storage stats, provenance, and machine-readable JSON plus Markdown summaries so benchmark runs can be compared across datasets and backends.
- The implementation includes shared metrics/provenance/storage helpers and hardens BM25/DiskANN baseline scripts so future benchmark work has a consistent artifact contract.
- Quality bar: unit tests cover benchmark generation, backend comparison manifests, query-log summaries, metrics, provenance, and baseline scripts; lint/format and diff checks were run.