### PR TITLE
feat: add video frame retrieval

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -659,14 +659,36 @@ jobs:
         run: |
           source .venv/bin/activate || source .venv/Scripts/activate
           python - <<'PY'
+          import numpy as np
           import leann
           import leann_backend_hnsw as h
           import leann_backend_diskann as d
           import leann_backend_ivf as ivf
           from leann import LeannBuilder, LeannSearcher
-          b = LeannBuilder(backend_name="hnsw")
+
+          b = LeannBuilder(
+              backend_name="hnsw",
+              dimensions=2,
+              is_compact=False,
+              is_recompute=False,
+          )
           b.add_text("hello arch")
-          b.build_index("arch_demo.leann")
-          s = LeannSearcher("arch_demo.leann")
-          print("search:", s.search("hello", top_k=1))
+          b.build_index_from_arrays(
+              "arch_demo.leann",
+              ["0"],
+              np.asarray([[1.0, 0.0]], dtype=np.float32),
+          )
+
+          with LeannSearcher(
+              "arch_demo.leann",
+              recompute_embeddings=False,
+              enable_warmup=False,
+          ) as s:
+              s.backend_impl.compute_query_embedding = lambda *args, **kwargs: np.asarray(
+                  [[1.0, 0.0]], dtype=np.float32
+              )
+              result = s.search("hello", top_k=1)
+
+          assert result and result[0].text == "hello arch"
+          print("arch smoke ok")
           PY

--- a/apps/video_rag.py
+++ b/apps/video_rag.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""
+CLIP Video RAG Application.
+
+This application indexes sampled video frames with CLIP embeddings so users can
+search local videos using text queries.
+
+Usage:
+    python -m apps.video_rag --video-dir ./my_videos --query "whiteboard diagram"
+    python -m apps.video_rag --video-dir ./my_videos --sample-interval-seconds 2
+"""
+
+import argparse
+import hashlib
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from leann.api import LeannChat
+from leann.registry import register_project_directory
+from PIL import Image
+from sentence_transformers import SentenceTransformer
+from tqdm import tqdm
+
+from apps.base_rag_example import BaseRAGExample, create_rag_session
+
+DEFAULT_VIDEO_EXTENSIONS = [".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v"]
+
+
+@dataclass(frozen=True)
+class VideoFrameRecord:
+    """A sampled RGB frame and the metadata needed to index it."""
+
+    image: Image.Image
+    frame_index: int
+    timestamp_seconds: float
+    fps: float
+    width: int
+    height: int
+    duration_seconds: float
+
+
+def normalize_video_extensions(extensions: Iterable[str]) -> set[str]:
+    """Normalize video extensions to lowercase dot-prefixed suffixes."""
+    normalized = set()
+    for extension in extensions:
+        stripped = extension.strip().lower()
+        if not stripped:
+            continue
+        normalized.add(stripped if stripped.startswith(".") else f".{stripped}")
+    return normalized
+
+
+def discover_video_files(video_dir: Path, extensions: Iterable[str]) -> list[Path]:
+    """Return video files in deterministic relative-path order."""
+    if not video_dir.exists():
+        raise ValueError(f"Video directory does not exist: {video_dir}")
+    if not video_dir.is_dir():
+        raise ValueError(f"Video path is not a directory: {video_dir}")
+
+    allowed_extensions = normalize_video_extensions(extensions)
+    if not allowed_extensions:
+        raise ValueError("At least one video extension must be provided.")
+
+    video_files = [
+        path
+        for path in video_dir.rglob("*")
+        if path.is_file() and path.suffix.lower() in allowed_extensions
+    ]
+    return sorted(
+        video_files,
+        key=lambda path: (
+            path.relative_to(video_dir).as_posix().lower(),
+            path.relative_to(video_dir).as_posix(),
+        ),
+    )
+
+
+def video_frame_passage_id(
+    video_dir: Path, video_path: Path, frame_index: int, timestamp_ms: int
+) -> str:
+    """Create a stable passage ID for a sampled frame."""
+    relative_path = video_path.relative_to(video_dir).as_posix()
+    key = f"{relative_path}:{frame_index}:{timestamp_ms}"
+    digest = hashlib.sha256(key.encode("utf-8", errors="surrogatepass")).hexdigest()
+    return f"video-frame-{digest[:16]}"
+
+
+def video_frame_text(
+    video_path: Path, video_dir: Path, timestamp_seconds: float, frame_index: int
+) -> str:
+    """Create the text payload stored alongside each sampled frame vector."""
+    relative_path = video_path.relative_to(video_dir).as_posix()
+    return (
+        f"Video frame: {video_path.name}\n"
+        f"Relative path: {relative_path}\n"
+        f"Timestamp: {timestamp_seconds:.3f}s\n"
+        f"Frame index: {frame_index}\n"
+        f"Path: {video_path}"
+    )
+
+
+def video_frame_metadata(
+    video_path: Path,
+    video_dir: Path,
+    embedding_model: str,
+    frame_index: int,
+    timestamp_seconds: float,
+    fps: float,
+    width: int,
+    height: int,
+    duration_seconds: float,
+) -> dict[str, Any]:
+    """Create JSON-serializable metadata for an indexed video frame."""
+    relative_path = video_path.relative_to(video_dir).as_posix()
+    timestamp_ms = round(timestamp_seconds * 1000)
+    stat = video_path.stat()
+    return {
+        "id": video_frame_passage_id(video_dir, video_path, frame_index, timestamp_ms),
+        "source": str(video_path),
+        "video_path": str(video_path),
+        "video_name": video_path.name,
+        "video_dir": str(video_dir),
+        "relative_path": relative_path,
+        "extension": video_path.suffix.lower(),
+        "media_type": "video_frame",
+        "frame_index": frame_index,
+        "timestamp_seconds": timestamp_seconds,
+        "timestamp_ms": timestamp_ms,
+        "fps": fps,
+        "width": width,
+        "height": height,
+        "duration_seconds": duration_seconds,
+        "size_bytes": stat.st_size,
+        "embedding_model": embedding_model,
+    }
+
+
+class VideoRAG(BaseRAGExample):
+    """RAG application for text-to-video-frame search using CLIP embeddings."""
+
+    embedding_model_default = "clip-ViT-L-14"
+    embedding_mode_default = "sentence-transformers"
+    max_items_default = -1
+
+    def __init__(self):
+        super().__init__(
+            name="Video RAG",
+            description="RAG application for searching sampled video frames with CLIP embeddings",
+            default_index_name="video_index",
+        )
+        self._video_data: list[dict[str, Any]] = []
+
+    def _add_specific_arguments(self, parser: argparse.ArgumentParser):
+        """Add video-specific arguments."""
+        video_group = parser.add_argument_group("Video Parameters")
+        video_group.add_argument(
+            "--video-dir",
+            type=str,
+            required=True,
+            help="Directory containing videos to index",
+        )
+        video_group.add_argument(
+            "--video-extensions",
+            type=str,
+            nargs="+",
+            default=DEFAULT_VIDEO_EXTENSIONS,
+            help="Video file extensions to process (default: .mp4 .mov .mkv .avi .webm .m4v)",
+        )
+        video_group.add_argument(
+            "--sample-interval-seconds",
+            type=float,
+            default=5.0,
+            help="Seconds between sampled frames (default: 5.0)",
+        )
+        video_group.add_argument(
+            "--max-frames-per-video",
+            type=int,
+            default=120,
+            help="Maximum sampled frames per video; use -1 for all sampled frames (default: 120)",
+        )
+        video_group.add_argument(
+            "--batch-size",
+            type=int,
+            default=32,
+            help="Batch size for CLIP frame embedding generation (default: 32)",
+        )
+
+    async def load_data(self, args) -> list[dict[str, Any]]:
+        """Load videos, generate CLIP frame embeddings, and return index records."""
+        self._video_data = self._load_videos_and_embeddings(args)
+        return [
+            {"text": entry["text"], "metadata": entry["metadata"]} for entry in self._video_data
+        ]
+
+    def _load_videos_and_embeddings(self, args) -> list[dict[str, Any]]:
+        """Sample video frames, encode them with CLIP, and attach metadata."""
+        video_dir = Path(args.video_dir).expanduser().resolve()
+        self._validate_video_args(args)
+
+        print(f"Loading videos from {video_dir}...")
+        video_files = discover_video_files(video_dir, args.video_extensions)
+        if not video_files:
+            raise ValueError(
+                f"No videos found in {video_dir} with extensions {args.video_extensions}"
+            )
+
+        print(f"Found {len(video_files)} videos")
+        if args.max_items > 0:
+            video_files = video_files[: args.max_items]
+            print(f"Processing {len(video_files)} videos (limited by --max-items)")
+
+        embedding_model = getattr(args, "embedding_model", self.embedding_model_default)
+        print("Loading CLIP model...")
+        model = self._load_clip_model(embedding_model)
+
+        print("Sampling frames and generating embeddings...")
+        video_data: list[dict[str, Any]] = []
+        batch_frames: list[Image.Image] = []
+        batch_context: list[tuple[Path, VideoFrameRecord]] = []
+
+        for video_path in tqdm(video_files, desc="Processing videos"):
+            try:
+                for frame_record in self._extract_video_frames(
+                    video_path=video_path,
+                    sample_interval_seconds=args.sample_interval_seconds,
+                    max_frames_per_video=args.max_frames_per_video,
+                ):
+                    batch_frames.append(frame_record.image)
+                    batch_context.append((video_path, frame_record))
+                    if len(batch_frames) >= args.batch_size:
+                        pending_frames = batch_frames
+                        pending_context = batch_context
+                        batch_frames = []
+                        batch_context = []
+                        video_data.extend(
+                            self._encode_frame_batch(
+                                model,
+                                pending_frames,
+                                pending_context,
+                                video_dir,
+                                embedding_model,
+                            )
+                        )
+            except Exception as exc:
+                print(f"Failed to process {video_path}: {exc}")
+                continue
+
+        if batch_frames:
+            video_data.extend(
+                self._encode_frame_batch(
+                    model,
+                    batch_frames,
+                    batch_context,
+                    video_dir,
+                    embedding_model,
+                )
+            )
+
+        if not video_data:
+            raise ValueError("No frames were extracted from the provided videos.")
+
+        print(f"Processed {len(video_data)} sampled video frames")
+        return video_data
+
+    def _validate_video_args(self, args) -> None:
+        if args.sample_interval_seconds <= 0:
+            raise ValueError("--sample-interval-seconds must be greater than 0")
+        if args.batch_size <= 0:
+            raise ValueError("--batch-size must be greater than 0")
+        if args.max_frames_per_video == 0 or args.max_frames_per_video < -1:
+            raise ValueError("--max-frames-per-video must be -1 or greater than 0")
+
+    def _load_clip_model(self, embedding_model: str):
+        """Load the configured CLIP encoder. Kept injectable for tests."""
+        return SentenceTransformer(embedding_model)
+
+    def _extract_video_frames(
+        self,
+        video_path: Path,
+        sample_interval_seconds: float,
+        max_frames_per_video: int,
+    ) -> Iterator[VideoFrameRecord]:
+        """Extract sampled RGB frames from one video using OpenCV."""
+        try:
+            import cv2
+        except ImportError:
+            raise RuntimeError(
+                "Video frame extraction requires OpenCV. Install it with "
+                "`pip install opencv-python-headless` or `uv sync --extra video`."
+            )
+
+        capture = cv2.VideoCapture(str(video_path))
+        try:
+            if not capture.isOpened():
+                raise RuntimeError("OpenCV could not open the video file.")
+
+            fps = float(capture.get(cv2.CAP_PROP_FPS) or 0.0)
+            frame_count = int(capture.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
+            width = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH) or 0)
+            height = int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT) or 0)
+            duration_seconds = frame_count / fps if fps > 0 and frame_count > 0 else 0.0
+
+            if fps <= 0 or frame_count <= 0:
+                raise RuntimeError("OpenCV did not report a usable frame count and frame rate.")
+
+            stride = max(1, round(sample_interval_seconds * fps))
+            sampled = 0
+            for frame_index in range(0, frame_count, stride):
+                if max_frames_per_video > 0 and sampled >= max_frames_per_video:
+                    break
+                capture.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
+                ok, frame = capture.read()
+                if not ok:
+                    continue
+                frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                image = Image.fromarray(frame_rgb).convert("RGB")
+                sampled += 1
+                yield VideoFrameRecord(
+                    image=image,
+                    frame_index=frame_index,
+                    timestamp_seconds=frame_index / fps,
+                    fps=fps,
+                    width=width,
+                    height=height,
+                    duration_seconds=duration_seconds,
+                )
+        finally:
+            capture.release()
+
+    def _encode_frame_batch(
+        self,
+        model,
+        frames: list[Image.Image],
+        frame_context: list[tuple[Path, VideoFrameRecord]],
+        video_dir: Path,
+        embedding_model: str,
+    ) -> list[dict[str, Any]]:
+        """Encode one sampled-frame batch and attach stable IDs/metadata."""
+        embeddings = model.encode(
+            frames,
+            convert_to_numpy=True,
+            normalize_embeddings=True,
+            batch_size=len(frames),
+            show_progress_bar=False,
+        )
+        embedding_array = np.asarray(embeddings, dtype=np.float32)
+        if embedding_array.shape[0] != len(frame_context):
+            raise RuntimeError(
+                f"CLIP encoder returned {embedding_array.shape[0]} embeddings for "
+                f"{len(frame_context)} sampled frames."
+            )
+
+        records = []
+        for (video_path, frame_record), embedding in zip(frame_context, embedding_array):
+            metadata = video_frame_metadata(
+                video_path=video_path,
+                video_dir=video_dir,
+                embedding_model=embedding_model,
+                frame_index=frame_record.frame_index,
+                timestamp_seconds=frame_record.timestamp_seconds,
+                fps=frame_record.fps,
+                width=frame_record.width,
+                height=frame_record.height,
+                duration_seconds=frame_record.duration_seconds,
+            )
+            records.append(
+                {
+                    "id": metadata["id"],
+                    "text": video_frame_text(
+                        video_path,
+                        video_dir,
+                        frame_record.timestamp_seconds,
+                        frame_record.frame_index,
+                    ),
+                    "metadata": metadata,
+                    "embedding": embedding.astype(np.float32),
+                }
+            )
+        return records
+
+    async def build_index(self, args, texts: list[dict[str, Any]]) -> str:
+        """Build an index using pre-computed CLIP frame embeddings."""
+        from leann.api import LeannBuilder
+
+        if not self._video_data or len(self._video_data) != len(texts):
+            raise RuntimeError("No video data found. Make sure load_data() ran successfully.")
+
+        print("Building LEANN index with CLIP video-frame embeddings...")
+        embedding_model = getattr(args, "embedding_model", self.embedding_model_default)
+        builder = LeannBuilder(
+            backend_name=args.backend_name,
+            embedding_model=embedding_model,
+            embedding_mode=self.embedding_mode_default,
+            is_recompute=False,
+            distance_metric="cosine",
+            graph_degree=args.graph_degree,
+            complexity=args.build_complexity,
+            is_compact=not args.no_compact,
+        )
+
+        for data in self._video_data:
+            builder.add_text(text=data["text"], metadata=data["metadata"])
+
+        ids = [data["id"] for data in self._video_data]
+        embeddings = np.array([data["embedding"] for data in self._video_data], dtype=np.float32)
+
+        index_path = str(Path(args.index_dir) / f"{self.default_index_name}.leann")
+        builder.build_index_from_arrays(index_path, ids, embeddings)
+        register_project_directory(Path.cwd())
+        print(f"Index built successfully at {index_path}")
+        return index_path
+
+    def _llm_kwargs(self, args) -> dict[str, Any]:
+        """Return optional LLM generation kwargs supported by the shared examples."""
+        llm_kwargs = {}
+        if hasattr(args, "thinking_budget") and args.thinking_budget:
+            llm_kwargs["thinking_budget"] = args.thinking_budget
+        return llm_kwargs
+
+    def _create_video_chat(self, args, index_path: str) -> LeannChat:
+        """Create a chat wrapper for a video-frame index."""
+        return LeannChat(
+            index_path,
+            llm_config=self.get_llm_config(args),
+            system_prompt=(
+                "You are a helpful assistant that answers questions about sampled video "
+                "frames indexed with CLIP embeddings."
+            ),
+            complexity=args.search_complexity,
+        )
+
+    async def run_interactive_chat(self, args, index_path: str):
+        """Run interactive chat with the video-frame index."""
+        chat = self._create_video_chat(args, index_path)
+        session = create_rag_session(
+            app_name=self.name.lower().replace(" ", "_"), data_description=self.name
+        )
+
+        def handle_query(query: str):
+            response = chat.ask(
+                query,
+                top_k=args.top_k,
+                complexity=args.search_complexity,
+                recompute_embeddings=False,
+                llm_kwargs=self._llm_kwargs(args),
+            )
+            print(f"\nAssistant: {response}\n")
+
+        session.run_interactive_loop(handle_query)
+
+    async def run_single_query(self, args, index_path: str, query: str):
+        """Run a single text-to-video-frame query without recomputing embeddings."""
+        chat = self._create_video_chat(args, index_path)
+
+        print(f"\n[Query]: \033[36m{query}\033[0m")
+        response = chat.ask(
+            query,
+            top_k=args.top_k,
+            complexity=args.search_complexity,
+            recompute_embeddings=False,
+            llm_kwargs=self._llm_kwargs(args),
+        )
+        print(f"\n[Response]: \033[36m{response}\033[0m")
+
+
+def main():
+    """Main entry point for the video RAG application."""
+    import asyncio
+
+    app = VideoRAG()
+    asyncio.run(app.run())
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,3 +18,14 @@ fixes). Newest entries at the bottom.
   at nprobe=32, ~6.5x lower single-query latency / ~75x higher batched throughput at
   comparable recall (GPU latency stays ~flat while CPU grows linearly with nprobe).
 - Docs: `docs/flashlib_backend_guide.md` gains a `flashlib_ivf` section.
+
+## 2026-06-03: Video frame retrieval
+
+- Add `apps/video_rag.py`, a CLIP-based video-frame retrieval example that samples local videos,
+  stores one precomputed CLIP embedding per sampled frame, and searches those frame vectors from
+  text queries without recomputing frame embeddings from metadata text.
+- Add stable `video-frame-<hash>` passage IDs plus frame metadata including relative path,
+  timestamp, frame index, frame size, duration, file size, media type, and embedding model.
+- Add `docs/video_rag.md`, a `video` optional dependency group for OpenCV/Pillow, and focused
+  mocked tests covering discovery, metadata, batching, precomputed-array builds, validation, and
+  no-recompute query execution.

--- a/docs/video_rag.md
+++ b/docs/video_rag.md
@@ -1,0 +1,59 @@
+# Video RAG
+
+`apps/video_rag.py` indexes sampled video frames with CLIP embeddings so a text query can retrieve
+the most relevant moments in local videos. It is intended for visual frame retrieval, not speech
+transcription or full video understanding.
+
+## Install
+
+From a source checkout, install the optional video dependencies:
+
+```bash
+uv sync --extra video
+```
+
+For a standalone environment, install OpenCV and Pillow alongside LEANN:
+
+```bash
+pip install leann opencv-python-headless pillow
+```
+
+## Build
+
+```bash
+python -m apps.video_rag --video-dir ./videos --index-dir ./video_index --force-rebuild
+```
+
+By default, LEANN samples one frame every five seconds and caps each video at 120 sampled frames.
+Use `--sample-interval-seconds` for denser or sparser sampling and `--max-frames-per-video -1` to
+disable the per-video cap.
+
+```bash
+python -m apps.video_rag \
+  --video-dir ./videos \
+  --sample-interval-seconds 2 \
+  --max-frames-per-video 300 \
+  --index-dir ./video_index \
+  --force-rebuild
+```
+
+## Search
+
+```bash
+python -m apps.video_rag \
+  --video-dir ./videos \
+  --index-dir ./video_index \
+  --query "slide with latency chart"
+```
+
+The index stores one passage per sampled frame. Each passage includes the video path, relative path,
+frame index, timestamp, frame size, video duration, and embedding model. Passage IDs are stable
+`video-frame-<hash>` values derived from the relative video path, frame index, and timestamp.
+
+## Notes
+
+- Supported default extensions are `.mp4`, `.mov`, `.mkv`, `.avi`, `.webm`, and `.m4v`.
+- Queries search CLIP text embeddings against precomputed CLIP frame embeddings. The app disables
+  LEANN embedding recomputation at query time because stored frame descriptions cannot recreate the
+  original pixels.
+- Codec support depends on the installed OpenCV build and platform media libraries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,11 @@ documents = [
     "pandas>=2.2.0",           # For data processing
 ]
 
+video = [
+    "opencv-python-headless>=4.10.0",
+    "pillow>=10.0.0",
+]
+
 [tool.setuptools]
 py-modules = []
 packages = ["wechat_exporter"]

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -9,15 +9,80 @@ from pathlib import Path
 
 import pytest
 
+CI_EMBEDDING_DIMENSIONS = 4
+
+
+def _is_ci() -> bool:
+    return os.environ.get("CI") == "true"
+
+
+def _install_ci_embeddings(monkeypatch):
+    """Use deterministic embeddings in CI so docs tests do not depend on model downloads."""
+    if not _is_ci():
+        return
+
+    import leann.api as leann_api
+    import leann.embedding_compute as embedding_compute
+    import numpy as np
+
+    def fake_compute_embeddings(
+        chunks,
+        model_name,
+        mode="sentence-transformers",
+        use_server=True,
+        port=None,
+        is_build=False,
+        provider_options=None,
+    ):
+        del model_name, mode, use_server, port, is_build, provider_options
+        embeddings = []
+        for chunk in chunks:
+            text = str(chunk).lower()
+            if (
+                "fantastical" in text
+                or "ai-generated" in text
+                or "banana" in text
+                or "crocodile" in text
+            ):
+                embeddings.append([1.0, 0.0, 0.0, 0.0])
+            elif "storage" in text or "97%" in text or "saves" in text:
+                embeddings.append([0.0, 1.0, 0.0, 0.0])
+            elif "llm" in text or "testing" in text:
+                embeddings.append([0.0, 0.0, 1.0, 0.0])
+            else:
+                embeddings.append([0.0, 0.0, 0.0, 1.0])
+        return np.asarray(embeddings, dtype=np.float32)
+
+    monkeypatch.setattr(leann_api, "compute_embeddings", fake_compute_embeddings)
+    monkeypatch.setattr(embedding_compute, "compute_embeddings", fake_compute_embeddings)
+
+
+def _ci_builder_kwargs() -> dict:
+    if not _is_ci():
+        return {}
+    return {
+        "embedding_model": "ci/deterministic-test-embedding",
+        "dimensions": CI_EMBEDDING_DIMENSIONS,
+        "is_compact": False,
+        "is_recompute": False,
+    }
+
+
+def _ci_searcher_kwargs() -> dict:
+    if not _is_ci():
+        return {}
+    return {"enable_warmup": False, "recompute_embeddings": False}
+
 
 @pytest.mark.parametrize("backend_name", ["hnsw", "diskann"])
-def test_readme_basic_example(backend_name):
+def test_readme_basic_example(backend_name, monkeypatch):
     """Test the basic example from README.md with both backends."""
+    _install_ci_embeddings(monkeypatch)
     # Skip on macOS CI due to MPS environment issues with all-MiniLM-L6-v2
-    if os.environ.get("CI") == "true" and platform.system() == "Darwin":
+    if _is_ci() and platform.system() == "Darwin":
         pytest.skip("Skipping on macOS CI due to MPS environment issues with all-MiniLM-L6-v2")
     # Skip DiskANN on CI (Linux runners) due to C++ extension memory/hardware constraints
-    if os.environ.get("CI") == "true" and backend_name == "diskann":
+    if _is_ci() and backend_name == "diskann":
         pytest.skip("Skip DiskANN tests in CI due to resource constraints and instability")
 
     # This is the exact code from README (with smaller model for CI)
@@ -27,11 +92,10 @@ def test_readme_basic_example(backend_name):
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         INDEX_PATH = str(Path(temp_dir) / f"demo_{backend_name}.leann")
 
-        if os.environ.get("CI") == "true":
+        if _is_ci():
             builder = LeannBuilder(
                 backend_name=backend_name,
-                embedding_model="sentence-transformers/all-MiniLM-L6-v2",
-                dimensions=384,
+                **_ci_builder_kwargs(),
             )
         else:
             builder = LeannBuilder(backend_name=backend_name)
@@ -44,8 +108,11 @@ def test_readme_basic_example(backend_name):
         index_files = list(index_dir.glob(f"{Path(INDEX_PATH).stem}.*"))
         assert len(index_files) > 0
 
-        with LeannSearcher(INDEX_PATH) as searcher:
-            results = searcher.search("fantastical AI-generated creatures", top_k=1)
+        with LeannSearcher(INDEX_PATH, **_ci_searcher_kwargs()) as searcher:
+            results = searcher.search(
+                "fantastical AI-generated creatures",
+                top_k=1,
+            )
 
             assert len(results) > 0
             assert isinstance(results[0], SearchResult)
@@ -54,8 +121,16 @@ def test_readme_basic_example(backend_name):
             )
             assert "banana" in results[0].text or "crocodile" in results[0].text
 
-        chat = LeannChat(INDEX_PATH, llm_config={"type": "simulated"})
-        response = chat.ask("How much storage does LEANN save?", top_k=1)
+        chat = LeannChat(
+            INDEX_PATH,
+            llm_config={"type": "simulated"},
+            **_ci_searcher_kwargs(),
+        )
+        response = chat.ask(
+            "How much storage does LEANN save?",
+            top_k=1,
+            recompute_embeddings=not _is_ci(),
+        )
 
         # Verify chat works
         assert isinstance(response, str)
@@ -75,31 +150,33 @@ def test_readme_imports():
     assert callable(LeannChat)
 
 
-def test_backend_options():
+def test_backend_options(monkeypatch):
     """Test different backend options mentioned in documentation."""
+    _install_ci_embeddings(monkeypatch)
     # Skip on macOS CI due to MPS environment issues with all-MiniLM-L6-v2
-    if os.environ.get("CI") == "true" and platform.system() == "Darwin":
+    if _is_ci() and platform.system() == "Darwin":
         pytest.skip("Skipping on macOS CI due to MPS environment issues with all-MiniLM-L6-v2")
 
     from leann import LeannBuilder
 
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
-        is_ci = os.environ.get("CI") == "true"
-        embedding_model = (
-            "sentence-transformers/all-MiniLM-L6-v2" if is_ci else "facebook/contriever"
-        )
-        dimensions = 384 if is_ci else None
-
         hnsw_path = str(Path(temp_dir) / "test_hnsw.leann")
-        builder_hnsw = LeannBuilder(
-            backend_name="hnsw", embedding_model=embedding_model, dimensions=dimensions
-        )
+        if _is_ci():
+            builder_hnsw = LeannBuilder(
+                backend_name="hnsw",
+                **_ci_builder_kwargs(),
+            )
+        else:
+            builder_hnsw = LeannBuilder(
+                backend_name="hnsw",
+                embedding_model="facebook/contriever",
+            )
         builder_hnsw.add_text("Test document for HNSW backend")
         builder_hnsw.build_index(hnsw_path)
         assert Path(hnsw_path).parent.exists()
         assert len(list(Path(hnsw_path).parent.glob(f"{Path(hnsw_path).stem}.*"))) > 0
 
-        if is_ci:
+        if _is_ci():
             pytest.skip(
                 "Skip DiskANN portion in CI - small datasets trigger MKL parameter "
                 "errors and pytest-timeout thread kills cause segfaults on Windows"
@@ -107,7 +184,8 @@ def test_backend_options():
 
         diskann_path = str(Path(temp_dir) / "test_diskann.leann")
         builder_diskann = LeannBuilder(
-            backend_name="diskann", embedding_model=embedding_model, dimensions=dimensions
+            backend_name="diskann",
+            embedding_model="facebook/contriever",
         )
         builder_diskann.add_text("Test document for DiskANN backend")
         builder_diskann.build_index(diskann_path)
@@ -116,25 +194,25 @@ def test_backend_options():
 
 
 @pytest.mark.parametrize("backend_name", ["hnsw", "diskann"])
-def test_llm_config_simulated(backend_name):
+def test_llm_config_simulated(backend_name, monkeypatch):
     """Test simulated LLM configuration option with both backends."""
+    _install_ci_embeddings(monkeypatch)
     # Skip on macOS CI due to MPS environment issues with all-MiniLM-L6-v2
-    if os.environ.get("CI") == "true" and platform.system() == "Darwin":
+    if _is_ci() and platform.system() == "Darwin":
         pytest.skip("Skipping on macOS CI due to MPS environment issues with all-MiniLM-L6-v2")
 
     # Skip DiskANN tests in CI due to hardware requirements
-    if os.environ.get("CI") == "true" and backend_name == "diskann":
+    if _is_ci() and backend_name == "diskann":
         pytest.skip("Skip DiskANN tests in CI - requires specific hardware and large memory")
 
     from leann import LeannBuilder, LeannChat
 
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         index_path = str(Path(temp_dir) / f"test_{backend_name}.leann")
-        if os.environ.get("CI") == "true":
+        if _is_ci():
             builder = LeannBuilder(
                 backend_name=backend_name,
-                embedding_model="sentence-transformers/all-MiniLM-L6-v2",
-                dimensions=384,
+                **_ci_builder_kwargs(),
             )
         else:
             builder = LeannBuilder(backend_name=backend_name)
@@ -142,8 +220,12 @@ def test_llm_config_simulated(backend_name):
         builder.build_index(index_path)
 
         llm_config = {"type": "simulated"}
-        chat = LeannChat(index_path, llm_config=llm_config)
-        response = chat.ask("What is this document about?", top_k=1)
+        chat = LeannChat(index_path, llm_config=llm_config, **_ci_searcher_kwargs())
+        response = chat.ask(
+            "What is this document about?",
+            top_k=1,
+            recompute_embeddings=not _is_ci(),
+        )
 
         assert isinstance(response, str)
         assert len(response) > 0

--- a/tests/test_video_rag.py
+++ b/tests/test_video_rag.py
@@ -1,11 +1,15 @@
 import asyncio
+import sys
 from collections.abc import Iterator
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
 import numpy as np
 import pytest
 from PIL import Image
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from apps import video_rag
 from apps.video_rag import VideoFrameRecord, VideoRAG

--- a/tests/test_video_rag.py
+++ b/tests/test_video_rag.py
@@ -1,0 +1,234 @@
+import asyncio
+from collections.abc import Iterator
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from apps import video_rag
+from apps.video_rag import VideoFrameRecord, VideoRAG
+
+
+def _write_video_placeholder(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"not a real video; tests mock decoding")
+
+
+def test_discover_video_files_is_deterministic_and_case_insensitive(tmp_path):
+    video_dir = tmp_path / "videos"
+    _write_video_placeholder(video_dir / "b" / "two.MP4")
+    _write_video_placeholder(video_dir / "A.mov")
+    (video_dir / "notes.txt").write_text("not a video", encoding="utf-8")
+
+    files = video_rag.discover_video_files(video_dir, ["mp4", ".mov"])
+
+    assert [path.relative_to(video_dir).as_posix() for path in files] == ["A.mov", "b/two.MP4"]
+
+
+def test_video_frame_metadata_has_stable_id_and_frame_fields(tmp_path):
+    video_dir = tmp_path / "videos"
+    video_path = video_dir / "nested" / "clip.MP4"
+    _write_video_placeholder(video_path)
+
+    metadata = video_rag.video_frame_metadata(
+        video_path=video_path,
+        video_dir=video_dir,
+        embedding_model="clip-test",
+        frame_index=42,
+        timestamp_seconds=1.4,
+        fps=30.0,
+        width=1920,
+        height=1080,
+        duration_seconds=10.0,
+    )
+
+    assert metadata["id"] == video_rag.video_frame_passage_id(video_dir, video_path, 42, 1400)
+    assert metadata["relative_path"] == "nested/clip.MP4"
+    assert metadata["extension"] == ".mp4"
+    assert metadata["media_type"] == "video_frame"
+    assert metadata["timestamp_ms"] == 1400
+    assert metadata["frame_index"] == 42
+    assert metadata["width"] == 1920
+    assert metadata["height"] == 1080
+    assert metadata["embedding_model"] == "clip-test"
+
+
+def test_load_videos_uses_fake_encoder_and_respects_limits(tmp_path):
+    video_dir = tmp_path / "videos"
+    _write_video_placeholder(video_dir / "first.mp4")
+    _write_video_placeholder(video_dir / "second.mp4")
+
+    class FakeModel:
+        def encode(self, frames, **kwargs):
+            assert kwargs["normalize_embeddings"] is True
+            return np.array([[1.0, 0.0] for _ in frames], dtype=np.float32)
+
+    class TestVideoRAG(VideoRAG):
+        def _load_clip_model(self, embedding_model: str):
+            return FakeModel()
+
+        def _extract_video_frames(
+            self,
+            video_path,
+            sample_interval_seconds: float,
+            max_frames_per_video: int,
+        ) -> Iterator[VideoFrameRecord]:
+            assert sample_interval_seconds == 2.0
+            for frame_index in range(3):
+                if max_frames_per_video > 0 and frame_index >= max_frames_per_video:
+                    break
+                yield VideoFrameRecord(
+                    image=Image.new("RGB", (2, 2), (frame_index, 0, 0)),
+                    frame_index=frame_index,
+                    timestamp_seconds=float(frame_index * 2),
+                    fps=30.0,
+                    width=2,
+                    height=2,
+                    duration_seconds=6.0,
+                )
+
+    app = TestVideoRAG()
+
+    records = app._load_videos_and_embeddings(
+        SimpleNamespace(
+            video_dir=str(video_dir),
+            video_extensions=[".mp4"],
+            max_items=1,
+            max_frames_per_video=2,
+            sample_interval_seconds=2.0,
+            batch_size=8,
+            embedding_model="clip-test",
+        )
+    )
+
+    assert len(records) == 2
+    assert records[0]["id"] == records[0]["metadata"]["id"]
+    assert records[0]["metadata"]["embedding_model"] == "clip-test"
+    assert records[0]["embedding"].dtype == np.float32
+    assert records[1]["metadata"]["frame_index"] == 1
+
+
+@pytest.mark.parametrize(
+    ("sample_interval_seconds", "batch_size", "max_frames_per_video", "message"),
+    [
+        (0.0, 8, 2, "sample-interval-seconds"),
+        (1.0, 0, 2, "batch-size"),
+        (1.0, 8, 0, "max-frames-per-video"),
+        (1.0, 8, -2, "max-frames-per-video"),
+    ],
+)
+def test_load_videos_rejects_invalid_args(
+    tmp_path, sample_interval_seconds, batch_size, max_frames_per_video, message
+):
+    video_dir = tmp_path / "videos"
+    _write_video_placeholder(video_dir / "first.mp4")
+    app = VideoRAG()
+
+    with pytest.raises(ValueError, match=message):
+        app._load_videos_and_embeddings(
+            SimpleNamespace(
+                video_dir=str(video_dir),
+                video_extensions=[".mp4"],
+                max_items=-1,
+                max_frames_per_video=max_frames_per_video,
+                sample_interval_seconds=sample_interval_seconds,
+                batch_size=batch_size,
+                embedding_model="clip-test",
+            )
+        )
+
+
+def test_build_index_uses_stable_ids_and_precomputed_arrays(tmp_path, monkeypatch):
+    calls = {}
+
+    class FakeBuilder:
+        def __init__(self, **kwargs):
+            calls["init"] = kwargs
+            self.texts = []
+
+        def add_text(self, text, metadata=None):
+            self.texts.append((text, metadata))
+
+        def build_index_from_arrays(self, index_path, ids, embeddings):
+            calls["build"] = {
+                "index_path": index_path,
+                "ids": ids,
+                "embeddings": embeddings,
+                "texts": self.texts,
+            }
+
+    monkeypatch.setattr(
+        video_rag, "register_project_directory", lambda path: calls.setdefault("registered", path)
+    )
+    monkeypatch.setattr("leann.api.LeannBuilder", FakeBuilder)
+
+    app = VideoRAG()
+    app._video_data = [
+        {
+            "id": "video-frame-alpha",
+            "text": "Video frame: alpha.mp4",
+            "metadata": {"id": "video-frame-alpha", "relative_path": "alpha.mp4"},
+            "embedding": np.array([1.0, 0.0], dtype=np.float32),
+        }
+    ]
+
+    index_path = asyncio.run(
+        app.build_index(
+            SimpleNamespace(
+                index_dir=str(tmp_path / "index"),
+                backend_name="hnsw",
+                graph_degree=16,
+                build_complexity=32,
+                no_compact=False,
+                embedding_model="clip-test",
+            ),
+            cast(list[dict[str, Any]], [{"text": "Video frame: alpha.mp4"}]),
+        ),
+    )
+
+    assert index_path.endswith("video_index.leann")
+    assert calls["init"]["embedding_model"] == "clip-test"
+    assert calls["init"]["embedding_mode"] == "sentence-transformers"
+    assert calls["init"]["is_recompute"] is False
+    assert calls["init"]["distance_metric"] == "cosine"
+    assert calls["build"]["ids"] == ["video-frame-alpha"]
+    assert calls["build"]["embeddings"].shape == (1, 2)
+    assert calls["build"]["texts"] == [
+        ("Video frame: alpha.mp4", {"id": "video-frame-alpha", "relative_path": "alpha.mp4"})
+    ]
+
+
+def test_single_query_disables_recompute_for_video_index(monkeypatch):
+    calls = {}
+
+    class FakeChat:
+        def __init__(self, index_path, **kwargs):
+            calls["init"] = {"index_path": index_path, **kwargs}
+
+        def ask(self, query, **kwargs):
+            calls["ask"] = {"query": query, **kwargs}
+            return "found frame"
+
+    monkeypatch.setattr(video_rag, "LeannChat", FakeChat)
+
+    app = VideoRAG()
+    args = SimpleNamespace(
+        llm="simulated",
+        llm_model=None,
+        llm_host=None,
+        llm_api_key=None,
+        llm_api_base=None,
+        search_complexity=64,
+        top_k=3,
+        thinking_budget=None,
+    )
+
+    asyncio.run(app.run_single_query(args, "video_index.leann", "whiteboard"))
+
+    assert calls["init"]["index_path"] == "video_index.leann"
+    assert calls["ask"]["query"] == "whiteboard"
+    assert calls["ask"]["top_k"] == 3
+    assert calls["ask"]["complexity"] == 64
+    assert calls["ask"]["recompute_embeddings"] is False

--- a/uv.lock
+++ b/uv.lock
@@ -3,9 +3,15 @@ revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 
 [[package]]
@@ -529,7 +535,9 @@ name = "contourpy"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -600,8 +608,12 @@ version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
@@ -1615,7 +1627,9 @@ name = "ipython"
 version = "8.37.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
     { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
@@ -1641,8 +1655,12 @@ version = "9.5.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
     { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
@@ -2006,6 +2024,30 @@ requires-dist = [
 provides-extras = ["query-server"]
 
 [[package]]
+name = "leann-backend-flashlib-ivf"
+version = "0.3.6"
+source = { editable = "packages/leann-backend-flashlib-ivf" }
+dependencies = [
+    { name = "flashlib" },
+    { name = "leann-core" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "torch" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "flashlib" },
+    { name = "leann-backend-hnsw", marker = "extra == 'query-server'", specifier = ">=0.3.6" },
+    { name = "leann-core", specifier = ">=0.3.6" },
+    { name = "msgpack", marker = "extra == 'query-server'", specifier = ">=1.0.0" },
+    { name = "numpy", specifier = ">=1.20.0" },
+    { name = "pyzmq", marker = "extra == 'query-server'", specifier = ">=23.0.0" },
+    { name = "torch" },
+]
+provides-extras = ["query-server"]
+
+[[package]]
 name = "leann-backend-hnsw"
 version = "0.3.7"
 source = { editable = "packages/leann-backend-hnsw" }
@@ -2158,6 +2200,14 @@ documents = [
 flashlib = [
     { name = "leann-backend-flashlib" },
 ]
+flashlib-ivf = [
+    { name = "leann-backend-flashlib-ivf" },
+]
+video = [
+    { name = "opencv-python-headless", version = "4.11.0.86", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "opencv-python-headless", version = "4.13.0.92", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pillow" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -2190,6 +2240,7 @@ requires-dist = [
     { name = "ipykernel", specifier = "==6.29.5" },
     { name = "leann-backend-diskann", marker = "extra == 'diskann'", editable = "packages/leann-backend-diskann" },
     { name = "leann-backend-flashlib", marker = "extra == 'flashlib'", editable = "packages/leann-backend-flashlib" },
+    { name = "leann-backend-flashlib-ivf", marker = "extra == 'flashlib-ivf'", editable = "packages/leann-backend-flashlib-ivf" },
     { name = "leann-backend-hnsw", editable = "packages/leann-backend-hnsw" },
     { name = "leann-core", editable = "packages/leann-core" },
     { name = "llama-index", specifier = ">=0.12.44" },
@@ -2203,10 +2254,12 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "ollama" },
     { name = "openai", specifier = ">=1.0.0" },
+    { name = "opencv-python-headless", marker = "extra == 'video'", specifier = ">=4.10.0" },
     { name = "openpyxl", marker = "extra == 'documents'", specifier = ">=3.1.0" },
     { name = "pandas", marker = "extra == 'documents'", specifier = ">=2.2.0" },
     { name = "pathspec", specifier = ">=0.12.1" },
     { name = "pdfplumber", specifier = ">=0.11.0" },
+    { name = "pillow", marker = "extra == 'video'", specifier = ">=10.0.0" },
     { name = "protobuf", specifier = "==4.25.3" },
     { name = "psutil", specifier = ">=5.8.0" },
     { name = "pybind11", specifier = ">=3.0.0" },
@@ -2230,7 +2283,7 @@ requires-dist = [
     { name = "tree-sitter-typescript", specifier = ">=0.20.0" },
     { name = "typer", specifier = ">=0.12.3" },
 ]
-provides-extras = ["diskann", "flashlib", "documents"]
+provides-extras = ["diskann", "flashlib", "flashlib-ivf", "documents", "video"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3140,7 +3193,9 @@ name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
 wheels = [
@@ -3153,8 +3208,12 @@ version = "3.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
 wheels = [
@@ -3227,9 +3286,15 @@ name = "numpy"
 version = "1.26.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
 wheels = [
@@ -3559,6 +3624,55 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/62/9f/d11cc7fb2d60af14a97dbef4e3c7b23917387995c257951fdc321d8efd0a/openai-1.109.0.tar.gz", hash = "sha256:701e26d13e3953524ba99f44cf5fbbda40eafd41ba15a8d85b76229a2693cfe5", size = 563971, upload-time = "2025-09-23T16:59:41.508Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/d3/d65e318e8d3b5845afaa5960d8da779988b4cb9f4e1ca82e588fed9c6a9d/openai-1.109.0-py3-none-any.whl", hash = "sha256:8c0910bdd4ee1274d5ff0354786bdd0bc79e68c158d5d2c19e24208b412e5792", size = 948421, upload-time = "2025-09-23T16:59:39.516Z" },
+]
+
+[[package]]
+name = "opencv-python-headless"
+version = "4.11.0.86"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+]
+dependencies = [
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/2f/5b2b3ba52c864848885ba988f24b7f105052f68da9ab0e693cc7c25b0b30/opencv-python-headless-4.11.0.86.tar.gz", hash = "sha256:996eb282ca4b43ec6a3972414de0e2331f5d9cda2b41091a49739c19fb843798", size = 95177929, upload-time = "2025-01-16T13:53:40.22Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/53/2c50afa0b1e05ecdb4603818e85f7d174e683d874ef63a6abe3ac92220c8/opencv_python_headless-4.11.0.86-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:48128188ade4a7e517237c8e1e11a9cdf5c282761473383e77beb875bb1e61ca", size = 37326460, upload-time = "2025-01-16T13:52:57.015Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/43/68555327df94bb9b59a1fd645f63fafb0762515344d2046698762fc19d58/opencv_python_headless-4.11.0.86-cp37-abi3-macosx_13_0_x86_64.whl", hash = "sha256:a66c1b286a9de872c343ee7c3553b084244299714ebb50fbdcd76f07ebbe6c81", size = 56723330, upload-time = "2025-01-16T13:55:45.731Z" },
+    { url = "https://files.pythonhosted.org/packages/45/be/1438ce43ebe65317344a87e4b150865c5585f4c0db880a34cdae5ac46881/opencv_python_headless-4.11.0.86-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6efabcaa9df731f29e5ea9051776715b1bdd1845d7c9530065c7951d2a2899eb", size = 29487060, upload-time = "2025-01-16T13:51:59.625Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5c/c139a7876099916879609372bfa513b7f1257f7f1a908b0bdc1c2328241b/opencv_python_headless-4.11.0.86-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e0a27c19dd1f40ddff94976cfe43066fbbe9dfbb2ec1907d66c19caef42a57b", size = 49969856, upload-time = "2025-01-16T13:53:29.654Z" },
+    { url = "https://files.pythonhosted.org/packages/95/dd/ed1191c9dc91abcc9f752b499b7928aacabf10567bb2c2535944d848af18/opencv_python_headless-4.11.0.86-cp37-abi3-win32.whl", hash = "sha256:f447d8acbb0b6f2808da71fddd29c1cdd448d2bc98f72d9bb78a7a898fc9621b", size = 29324425, upload-time = "2025-01-16T13:52:49.048Z" },
+    { url = "https://files.pythonhosted.org/packages/86/8a/69176a64335aed183529207ba8bc3d329c2999d852b4f3818027203f50e6/opencv_python_headless-4.11.0.86-cp37-abi3-win_amd64.whl", hash = "sha256:6c304df9caa7a6a5710b91709dd4786bf20a74d57672b3c31f7033cc638174ca", size = 39402386, upload-time = "2025-01-16T13:52:56.418Z" },
+]
+
+[[package]]
+name = "opencv-python-headless"
+version = "4.13.0.92"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/42/2310883be3b8826ac58c3f2787b9358a2d46923d61f88fedf930bc59c60c/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:1a7d040ac656c11b8c38677cc8cccdc149f98535089dbe5b081e80a4e5903209", size = 46247192, upload-time = "2026-02-05T07:01:35.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/1e/6f9e38005a6f7f22af785df42a43139d0e20f169eb5787ce8be37ee7fcc9/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:3e0a6f0a37994ec6ce5f59e936be21d5d6384a4556f2d2da9c2f9c5dc948394c", size = 32568914, upload-time = "2026-02-05T07:01:51.989Z" },
+    { url = "https://files.pythonhosted.org/packages/21/76/9417a6aef9def70e467a5bf560579f816148a4c658b7d525581b356eda9e/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c8cfc8e87ed452b5cecb9419473ee5560a989859fe1d10d1ce11ae87b09a2cb", size = 33703709, upload-time = "2026-02-05T10:24:46.469Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ce/bd17ff5772938267fd49716e94ca24f616ff4cb1ff4c6be13085108037be/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0525a3d2c0b46c611e2130b5fdebc94cf404845d8fa64d2f3a3b679572a5bd22", size = 56016764, upload-time = "2026-02-05T10:26:48.904Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b4/b7bcbf7c874665825a8c8e1097e93ea25d1f1d210a3e20d4451d01da30aa/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb60e36b237b1ebd40a912da5384b348df8ed534f6f644d8e0b4f103e272ba7d", size = 35010236, upload-time = "2026-02-05T10:28:11.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/33/b5db29a6c00eb8f50708110d8d453747ca125c8b805bc437b289dbdcc057/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0bd48544f77c68b2941392fcdf9bcd2b9cdf00e98cb8c29b2455d194763cf99e", size = 60391106, upload-time = "2026-02-05T10:30:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c3/52cfea47cd33e53e8c0fbd6e7c800b457245c1fda7d61660b4ffe9596a7f/opencv_python_headless-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:a7cf08e5b191f4ebb530791acc0825a7986e0d0dee2a3c491184bd8599848a4b", size = 30812232, upload-time = "2026-02-05T07:02:29.594Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/90/b338326131ccb2aaa3c2c85d00f41822c0050139a4bfe723cfd95455bd2d/opencv_python_headless-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:77a82fe35ddcec0f62c15f2ba8a12ecc2ed4207c17b0902c7a3151ae29f37fb6", size = 40070414, upload-time = "2026-02-05T07:02:26.448Z" },
 ]
 
 [[package]]
@@ -4879,7 +4993,9 @@ name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -4939,8 +5055,12 @@ version = "1.16.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },


### PR DESCRIPTION
## Evaluator Summary

- Abi added frame-level video retrieval by sampling local video frames, embedding them with CLIP, and indexing each sampled frame as a searchable LEANN passage.
- Design choice: each frame gets a stable `video-frame-<hash>` ID plus timestamp, frame index, frame size, duration, source path, media type, and model metadata, so search results point back into the original video.
- The implementation builds from precomputed CLIP frame arrays and disables query-time recomputation for frame vectors, matching the image-retrieval design while keeping visual retrieval separate from audio transcription.
- Quality bar: 9 targeted tests mock decoding and model inference to avoid codec/model downloads while covering sampling, metadata, stable IDs, and retrieval wiring, plus lint, format, type, lockfile, and whitespace checks.
