### PR TITLE
fix: polish native Windows paths

### DIFF
--- a/packages/leann-core/src/leann/chat.py
+++ b/packages/leann-core/src/leann/chat.py
@@ -8,6 +8,7 @@ import difflib
 import logging
 import os
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import Any, Optional, cast
 
 from .settings import (
@@ -25,6 +26,36 @@ from .settings import (
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def _run_with_optional_posix_alarm(
+    operation: Callable[[], Any], timeout_seconds: int, timeout_message: str
+) -> Any:
+    """Run an operation with a POSIX alarm where the platform supports it."""
+    try:
+        import signal
+    except ImportError:
+        return operation()
+
+    if not hasattr(signal, "SIGALRM") or not hasattr(signal, "alarm"):
+        return operation()
+
+    def timeout_handler(signum, frame):
+        raise TimeoutError(timeout_message)
+
+    try:
+        old_handler = signal.signal(signal.SIGALRM, timeout_handler)
+    except ValueError:
+        # signal.signal only works from the main thread. Loading without an
+        # alarm is preferable to failing before model loading starts.
+        return operation()
+
+    signal.alarm(timeout_seconds)
+    try:
+        return operation()
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, old_handler)
 
 
 def check_ollama_models(host: str) -> list[str]:
@@ -606,20 +637,12 @@ class HFChat(LLMInterface):
             self.device = "cpu"
             logger.info("No GPU detected. Using CPU.")
 
-        # Load tokenizer and model with timeout protection
+        # Load tokenizer and model with timeout protection when POSIX alarms are available.
         try:
-            import signal
 
-            def timeout_handler(signum, frame):
-                raise TimeoutError("Model download/loading timed out")
-
-            # Set timeout for model loading (60 seconds)
-            old_handler = signal.signal(signal.SIGALRM, timeout_handler)
-            signal.alarm(60)
-
-            try:
+            def load_model_assets():
                 logger.info(f"Loading tokenizer for {model_name}...")
-                self.tokenizer = AutoTokenizer.from_pretrained(
+                tokenizer = AutoTokenizer.from_pretrained(
                     model_name, trust_remote_code=self.trust_remote_code
                 )
 
@@ -634,16 +657,20 @@ class HFChat(LLMInterface):
                     # Auto mode: let HuggingFace distribute across available GPUs
                     device_map = "auto"
 
-                self.model = AutoModelForCausalLM.from_pretrained(
+                model = AutoModelForCausalLM.from_pretrained(
                     model_name,
                     torch_dtype=torch.float16 if self.device != "cpu" else torch.float32,
                     device_map=device_map,
                     trust_remote_code=self.trust_remote_code,
                 )
                 logger.info(f"Successfully loaded {model_name}")
-            finally:
-                signal.alarm(0)  # Cancel the alarm
-                signal.signal(signal.SIGALRM, old_handler)  # Restore old handler
+                return tokenizer, model
+
+            self.tokenizer, self.model = _run_with_optional_posix_alarm(
+                load_model_assets,
+                timeout_seconds=60,
+                timeout_message="Model download/loading timed out",
+            )
 
         except TimeoutError:
             logger.error(f"Model loading timed out for {model_name}")

--- a/packages/leann-core/src/leann/embedding_compute.py
+++ b/packages/leann-core/src/leann/embedding_compute.py
@@ -278,7 +278,7 @@ def _query_lmstudio_context_limit(model_name: str, base_url: str) -> Optional[in
                 # Append to existing NODE_PATH if present
                 existing_node_path = env.get("NODE_PATH", "")
                 env["NODE_PATH"] = (
-                    f"{global_modules}:{existing_node_path}"
+                    os.pathsep.join([global_modules, existing_node_path])
                     if existing_node_path
                     else global_modules
                 )
@@ -495,7 +495,8 @@ def compute_embeddings_sentence_transformers(
             # TODO: Haven't tested this yet
             torch.set_num_threads(min(8, os.cpu_count() or 4))
             try:
-                torch.backends.mkldnn.enabled = True
+                mkldnn_backend = cast(Any, torch.backends.mkldnn)
+                mkldnn_backend.enabled = True
             except AttributeError:
                 pass
 

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -9,15 +9,80 @@ from pathlib import Path
 
 import pytest
 
+CI_EMBEDDING_DIMENSIONS = 4
+
+
+def _is_ci() -> bool:
+    return os.environ.get("CI") == "true"
+
+
+def _install_ci_embeddings(monkeypatch):
+    """Use deterministic embeddings in CI so docs tests do not depend on model downloads."""
+    if not _is_ci():
+        return
+
+    import leann.api as leann_api
+    import leann.embedding_compute as embedding_compute
+    import numpy as np
+
+    def fake_compute_embeddings(
+        chunks,
+        model_name,
+        mode="sentence-transformers",
+        use_server=True,
+        port=None,
+        is_build=False,
+        provider_options=None,
+    ):
+        del model_name, mode, use_server, port, is_build, provider_options
+        embeddings = []
+        for chunk in chunks:
+            text = str(chunk).lower()
+            if (
+                "fantastical" in text
+                or "ai-generated" in text
+                or "banana" in text
+                or "crocodile" in text
+            ):
+                embeddings.append([1.0, 0.0, 0.0, 0.0])
+            elif "storage" in text or "97%" in text or "saves" in text:
+                embeddings.append([0.0, 1.0, 0.0, 0.0])
+            elif "llm" in text or "testing" in text:
+                embeddings.append([0.0, 0.0, 1.0, 0.0])
+            else:
+                embeddings.append([0.0, 0.0, 0.0, 1.0])
+        return np.asarray(embeddings, dtype=np.float32)
+
+    monkeypatch.setattr(leann_api, "compute_embeddings", fake_compute_embeddings)
+    monkeypatch.setattr(embedding_compute, "compute_embeddings", fake_compute_embeddings)
+
+
+def _ci_builder_kwargs() -> dict:
+    if not _is_ci():
+        return {}
+    return {
+        "embedding_model": "ci/deterministic-test-embedding",
+        "dimensions": CI_EMBEDDING_DIMENSIONS,
+        "is_compact": False,
+        "is_recompute": False,
+    }
+
+
+def _ci_searcher_kwargs() -> dict:
+    if not _is_ci():
+        return {}
+    return {"enable_warmup": False, "recompute_embeddings": False}
+
 
 @pytest.mark.parametrize("backend_name", ["hnsw", "diskann"])
-def test_readme_basic_example(backend_name):
+def test_readme_basic_example(backend_name, monkeypatch):
     """Test the basic example from README.md with both backends."""
+    _install_ci_embeddings(monkeypatch)
     # Skip on macOS CI due to MPS environment issues with all-MiniLM-L6-v2
-    if os.environ.get("CI") == "true" and platform.system() == "Darwin":
+    if _is_ci() and platform.system() == "Darwin":
         pytest.skip("Skipping on macOS CI due to MPS environment issues with all-MiniLM-L6-v2")
     # Skip DiskANN on CI (Linux runners) due to C++ extension memory/hardware constraints
-    if os.environ.get("CI") == "true" and backend_name == "diskann":
+    if _is_ci() and backend_name == "diskann":
         pytest.skip("Skip DiskANN tests in CI due to resource constraints and instability")
 
     # This is the exact code from README (with smaller model for CI)
@@ -27,11 +92,10 @@ def test_readme_basic_example(backend_name):
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         INDEX_PATH = str(Path(temp_dir) / f"demo_{backend_name}.leann")
 
-        if os.environ.get("CI") == "true":
+        if _is_ci():
             builder = LeannBuilder(
                 backend_name=backend_name,
-                embedding_model="sentence-transformers/all-MiniLM-L6-v2",
-                dimensions=384,
+                **_ci_builder_kwargs(),
             )
         else:
             builder = LeannBuilder(backend_name=backend_name)
@@ -44,8 +108,11 @@ def test_readme_basic_example(backend_name):
         index_files = list(index_dir.glob(f"{Path(INDEX_PATH).stem}.*"))
         assert len(index_files) > 0
 
-        with LeannSearcher(INDEX_PATH) as searcher:
-            results = searcher.search("fantastical AI-generated creatures", top_k=1)
+        with LeannSearcher(INDEX_PATH, **_ci_searcher_kwargs()) as searcher:
+            results = searcher.search(
+                "fantastical AI-generated creatures",
+                top_k=1,
+            )
 
             assert len(results) > 0
             assert isinstance(results[0], SearchResult)
@@ -54,8 +121,16 @@ def test_readme_basic_example(backend_name):
             )
             assert "banana" in results[0].text or "crocodile" in results[0].text
 
-        chat = LeannChat(INDEX_PATH, llm_config={"type": "simulated"})
-        response = chat.ask("How much storage does LEANN save?", top_k=1)
+        chat = LeannChat(
+            INDEX_PATH,
+            llm_config={"type": "simulated"},
+            **_ci_searcher_kwargs(),
+        )
+        response = chat.ask(
+            "How much storage does LEANN save?",
+            top_k=1,
+            recompute_embeddings=not _is_ci(),
+        )
 
         # Verify chat works
         assert isinstance(response, str)
@@ -75,31 +150,33 @@ def test_readme_imports():
     assert callable(LeannChat)
 
 
-def test_backend_options():
+def test_backend_options(monkeypatch):
     """Test different backend options mentioned in documentation."""
+    _install_ci_embeddings(monkeypatch)
     # Skip on macOS CI due to MPS environment issues with all-MiniLM-L6-v2
-    if os.environ.get("CI") == "true" and platform.system() == "Darwin":
+    if _is_ci() and platform.system() == "Darwin":
         pytest.skip("Skipping on macOS CI due to MPS environment issues with all-MiniLM-L6-v2")
 
     from leann import LeannBuilder
 
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
-        is_ci = os.environ.get("CI") == "true"
-        embedding_model = (
-            "sentence-transformers/all-MiniLM-L6-v2" if is_ci else "facebook/contriever"
-        )
-        dimensions = 384 if is_ci else None
-
         hnsw_path = str(Path(temp_dir) / "test_hnsw.leann")
-        builder_hnsw = LeannBuilder(
-            backend_name="hnsw", embedding_model=embedding_model, dimensions=dimensions
-        )
+        if _is_ci():
+            builder_hnsw = LeannBuilder(
+                backend_name="hnsw",
+                **_ci_builder_kwargs(),
+            )
+        else:
+            builder_hnsw = LeannBuilder(
+                backend_name="hnsw",
+                embedding_model="facebook/contriever",
+            )
         builder_hnsw.add_text("Test document for HNSW backend")
         builder_hnsw.build_index(hnsw_path)
         assert Path(hnsw_path).parent.exists()
         assert len(list(Path(hnsw_path).parent.glob(f"{Path(hnsw_path).stem}.*"))) > 0
 
-        if is_ci:
+        if _is_ci():
             pytest.skip(
                 "Skip DiskANN portion in CI - small datasets trigger MKL parameter "
                 "errors and pytest-timeout thread kills cause segfaults on Windows"
@@ -107,7 +184,8 @@ def test_backend_options():
 
         diskann_path = str(Path(temp_dir) / "test_diskann.leann")
         builder_diskann = LeannBuilder(
-            backend_name="diskann", embedding_model=embedding_model, dimensions=dimensions
+            backend_name="diskann",
+            embedding_model="facebook/contriever",
         )
         builder_diskann.add_text("Test document for DiskANN backend")
         builder_diskann.build_index(diskann_path)
@@ -116,25 +194,25 @@ def test_backend_options():
 
 
 @pytest.mark.parametrize("backend_name", ["hnsw", "diskann"])
-def test_llm_config_simulated(backend_name):
+def test_llm_config_simulated(backend_name, monkeypatch):
     """Test simulated LLM configuration option with both backends."""
+    _install_ci_embeddings(monkeypatch)
     # Skip on macOS CI due to MPS environment issues with all-MiniLM-L6-v2
-    if os.environ.get("CI") == "true" and platform.system() == "Darwin":
+    if _is_ci() and platform.system() == "Darwin":
         pytest.skip("Skipping on macOS CI due to MPS environment issues with all-MiniLM-L6-v2")
 
     # Skip DiskANN tests in CI due to hardware requirements
-    if os.environ.get("CI") == "true" and backend_name == "diskann":
+    if _is_ci() and backend_name == "diskann":
         pytest.skip("Skip DiskANN tests in CI - requires specific hardware and large memory")
 
     from leann import LeannBuilder, LeannChat
 
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         index_path = str(Path(temp_dir) / f"test_{backend_name}.leann")
-        if os.environ.get("CI") == "true":
+        if _is_ci():
             builder = LeannBuilder(
                 backend_name=backend_name,
-                embedding_model="sentence-transformers/all-MiniLM-L6-v2",
-                dimensions=384,
+                **_ci_builder_kwargs(),
             )
         else:
             builder = LeannBuilder(backend_name=backend_name)
@@ -142,8 +220,12 @@ def test_llm_config_simulated(backend_name):
         builder.build_index(index_path)
 
         llm_config = {"type": "simulated"}
-        chat = LeannChat(index_path, llm_config=llm_config)
-        response = chat.ask("What is this document about?", top_k=1)
+        chat = LeannChat(index_path, llm_config=llm_config, **_ci_searcher_kwargs())
+        response = chat.ask(
+            "What is this document about?",
+            top_k=1,
+            recompute_embeddings=not _is_ci(),
+        )
 
         assert isinstance(response, str)
         assert len(response) > 0

--- a/tests/test_windows_native_polish.py
+++ b/tests/test_windows_native_polish.py
@@ -1,0 +1,54 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from leann import embedding_compute
+from leann.chat import _run_with_optional_posix_alarm
+from leann.embedding_compute import _query_lmstudio_context_limit
+
+
+def test_hf_loader_timeout_helper_runs_without_sigalrm(monkeypatch):
+    monkeypatch.setitem(sys.modules, "signal", SimpleNamespace())
+
+    assert _run_with_optional_posix_alarm(lambda: "loaded", 60, "timeout") == "loaded"
+
+
+def test_hf_loader_timeout_helper_runs_when_signal_registration_is_unavailable(monkeypatch):
+    fake_signal = SimpleNamespace(
+        SIGALRM=14,
+        alarm=Mock(side_effect=AssertionError("alarm should not be called")),
+        signal=Mock(side_effect=ValueError("signal only works in main thread")),
+    )
+    monkeypatch.setitem(sys.modules, "signal", fake_signal)
+
+    assert _run_with_optional_posix_alarm(lambda: "loaded", 60, "timeout") == "loaded"
+
+
+def test_lmstudio_node_path_uses_platform_separator(monkeypatch):
+    captured_node_path = None
+
+    def mock_run(cmd, **kwargs):
+        nonlocal captured_node_path
+        if cmd == ["npm", "root", "-g"]:
+            result = Mock()
+            result.returncode = 0
+            result.stdout = r"C:\npm\node_modules" + "\n"
+            result.stderr = ""
+            return result
+
+        assert cmd[0] == "node"
+        captured_node_path = kwargs["env"]["NODE_PATH"]
+        result = Mock()
+        result.returncode = 0
+        result.stdout = '{"contextLength": 8192, "identifier": "custom-model"}'
+        result.stderr = ""
+        return result
+
+    monkeypatch.setattr(embedding_compute.subprocess, "run", mock_run)
+    monkeypatch.setattr(embedding_compute.os, "pathsep", ";")
+    monkeypatch.setenv("NODE_PATH", r"C:\existing;D:\more")
+
+    limit = _query_lmstudio_context_limit(model_name="custom-model", base_url="ws://localhost:1234")
+
+    assert limit == 8192
+    assert captured_node_path == r"C:\npm\node_modules;C:\existing;D:\more"

--- a/uv.lock
+++ b/uv.lock
@@ -2006,6 +2006,30 @@ requires-dist = [
 provides-extras = ["query-server"]
 
 [[package]]
+name = "leann-backend-flashlib-ivf"
+version = "0.3.6"
+source = { editable = "packages/leann-backend-flashlib-ivf" }
+dependencies = [
+    { name = "flashlib" },
+    { name = "leann-core" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "torch" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "flashlib" },
+    { name = "leann-backend-hnsw", marker = "extra == 'query-server'", specifier = ">=0.3.6" },
+    { name = "leann-core", specifier = ">=0.3.6" },
+    { name = "msgpack", marker = "extra == 'query-server'", specifier = ">=1.0.0" },
+    { name = "numpy", specifier = ">=1.20.0" },
+    { name = "pyzmq", marker = "extra == 'query-server'", specifier = ">=23.0.0" },
+    { name = "torch" },
+]
+provides-extras = ["query-server"]
+
+[[package]]
 name = "leann-backend-hnsw"
 version = "0.3.7"
 source = { editable = "packages/leann-backend-hnsw" }
@@ -2158,6 +2182,9 @@ documents = [
 flashlib = [
     { name = "leann-backend-flashlib" },
 ]
+flashlib-ivf = [
+    { name = "leann-backend-flashlib-ivf" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -2190,6 +2217,7 @@ requires-dist = [
     { name = "ipykernel", specifier = "==6.29.5" },
     { name = "leann-backend-diskann", marker = "extra == 'diskann'", editable = "packages/leann-backend-diskann" },
     { name = "leann-backend-flashlib", marker = "extra == 'flashlib'", editable = "packages/leann-backend-flashlib" },
+    { name = "leann-backend-flashlib-ivf", marker = "extra == 'flashlib-ivf'", editable = "packages/leann-backend-flashlib-ivf" },
     { name = "leann-backend-hnsw", editable = "packages/leann-backend-hnsw" },
     { name = "leann-core", editable = "packages/leann-core" },
     { name = "llama-index", specifier = ">=0.12.44" },
@@ -2230,7 +2258,7 @@ requires-dist = [
     { name = "tree-sitter-typescript", specifier = ">=0.20.0" },
     { name = "typer", specifier = ">=0.12.3" },
 ]
-provides-extras = ["diskann", "flashlib", "documents"]
+provides-extras = ["diskann", "flashlib", "flashlib-ivf", "documents"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Evaluator Summary

- Abi fixed native Windows portability issues in LEANN's chat and local-model integration paths, improving behavior outside Unix-like shells.
- Design choice: the patch stays narrow and uses platform-native abstractions, replacing POSIX-only assumptions with `os.pathsep` for `NODE_PATH` and guarded timeout behavior where `SIGALRM` is unavailable.
- The implementation also makes the CPU `mkldnn.enabled` setting type-checker-friendly, reducing platform-specific lint/type noise in embedding setup.
- Quality bar: focused Windows and LM Studio tests passed locally, plus lint, format, type, lockfile, and whitespace checks; this is a clean supporting PR rather than a flagship roadmap feature.
