### PR TITLE
feat: default passage IDs to content-hash

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,3 +18,14 @@ fixes). Newest entries at the bottom.
   at nprobe=32, ~6.5x lower single-query latency / ~75x higher batched throughput at
   comparable recall (GPU latency stays ~flat while CPU grows linearly with nprobe).
 - Docs: `docs/flashlib_backend_guide.md` gains a `flashlib_ivf` section.
+
+## 2026-06-07: Content-hash passage IDs as the default
+
+- Make `content-hash` the default generated passage ID scheme so new indexes use
+  `sha256(text)[:16]` IDs that remain stable across file moves and chunk reorderings.
+- Preserve existing index ID schemes during incremental updates: legacy sequential
+  indexes continue appending sequential IDs, while content-hash indexes append
+  content-derived IDs.
+- Mark precomputed embedding array builds as `external` ID indexes and align passage
+  JSONL, offset maps, backend labels, and metadata to the caller-provided IDs.
+- Serialize full-rebuild publish and ID-migration rewrites with an index write lock.

--- a/packages/leann-core/src/leann/api.py
+++ b/packages/leann-core/src/leann/api.py
@@ -31,13 +31,16 @@ from .registry import BACKEND_REGISTRY
 logger = logging.getLogger(__name__)
 
 # Passage ID schemes recorded in <index>.meta.json["passage_id_scheme"].
-# - "sequential": today's default; IDs are str(insertion_index) (api.py:add_text).
-# - "content-hash": planned in #329; IDs are sha256(text)[:16], stable across
+# - "sequential": legacy default; IDs are str(insertion_index) (api.py:add_text).
+# - "content-hash": default for generated IDs; IDs are sha256(text)[:16], stable across
 #   file moves and reorderings.
+# - "external": caller-provided IDs, primarily for build_index_from_arrays().
 # Older indexes have no passage_id_scheme field — readers must default to
 # "sequential" when the key is absent. See #329 for the rollout plan.
 PASSAGE_ID_SCHEME_SEQUENTIAL = "sequential"
 PASSAGE_ID_SCHEME_CONTENT_HASH = "content-hash"
+PASSAGE_ID_SCHEME_EXTERNAL = "external"
+DEFAULT_PASSAGE_ID_SCHEME = PASSAGE_ID_SCHEME_CONTENT_HASH
 
 
 def get_registered_backends() -> list[str]:
@@ -385,7 +388,7 @@ class LeannBuilder:
         embedding_options: Optional[dict[str, Any]] = None,
         prebuild_bm25: bool = False,
         bm25_backend: str = "fts5",
-        passage_id_scheme: str = PASSAGE_ID_SCHEME_SEQUENTIAL,
+        passage_id_scheme: str = DEFAULT_PASSAGE_ID_SCHEME,
         **backend_kwargs,
     ):
         if bm25_backend != "fts5":
@@ -396,11 +399,13 @@ class LeannBuilder:
         if passage_id_scheme not in (
             PASSAGE_ID_SCHEME_SEQUENTIAL,
             PASSAGE_ID_SCHEME_CONTENT_HASH,
+            PASSAGE_ID_SCHEME_EXTERNAL,
         ):
             raise ValueError(
                 f"Unknown passage_id_scheme: {passage_id_scheme!r}. "
                 f"Expected one of: {PASSAGE_ID_SCHEME_SEQUENTIAL!r}, "
-                f"{PASSAGE_ID_SCHEME_CONTENT_HASH!r}."
+                f"{PASSAGE_ID_SCHEME_CONTENT_HASH!r}, "
+                f"{PASSAGE_ID_SCHEME_EXTERNAL!r}."
             )
         self.passage_id_scheme = passage_id_scheme
         self.backend_name = backend_name
@@ -500,7 +505,7 @@ class LeannBuilder:
     def _generate_passage_id(self, text: str) -> str:
         """Generate a passage ID per the configured scheme.
 
-        sequential: str(insertion index) — fast, position-dependent, current default.
+        sequential: str(insertion index) — fast, position-dependent, legacy default.
         content-hash: sha256(text)[:16] — content-stable, dedup-friendly across
         file moves and reorderings. See #329 for the design.
         """
@@ -508,14 +513,60 @@ class LeannBuilder:
             import hashlib
 
             return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+        if self.passage_id_scheme == PASSAGE_ID_SCHEME_EXTERNAL:
+            raise ValueError("passage_id_scheme='external' requires explicit metadata['id'].")
         return str(len(self.chunks))
 
     def add_text(self, text: str, metadata: Optional[dict[str, Any]] = None):
         if metadata is None:
             metadata = {}
-        passage_id = metadata.get("id") or self._generate_passage_id(text)
+        explicit_id = metadata.get("id")
+        if explicit_id is None:
+            passage_id = self._generate_passage_id(text)
+            generated_id_scheme: Optional[str] = self.passage_id_scheme
+        else:
+            passage_id = str(explicit_id)
+            generated_id_scheme = None
         chunk_data = {"id": passage_id, "text": text, "metadata": metadata}
+        if generated_id_scheme is not None:
+            chunk_data["_generated_id_scheme"] = generated_id_scheme
         self.chunks.append(chunk_data)
+
+    @staticmethod
+    def _content_hash_passage_id(text: str) -> str:
+        import hashlib
+
+        return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+    def _assign_passage_ids_for_existing_scheme(
+        self,
+        chunks: list[dict[str, Any]],
+        passage_id_scheme: str,
+        start_index: int,
+    ) -> None:
+        """Assign passage IDs for an update using the existing index's scheme."""
+        for offset, chunk in enumerate(chunks):
+            metadata = chunk.setdefault("metadata", {})
+            explicit_id = metadata.get("id")
+            generated_scheme = chunk.get("_generated_id_scheme")
+            if explicit_id is not None and generated_scheme is None:
+                passage_id = str(explicit_id)
+            elif passage_id_scheme == PASSAGE_ID_SCHEME_CONTENT_HASH:
+                passage_id = self._content_hash_passage_id(chunk["text"])
+            elif passage_id_scheme == PASSAGE_ID_SCHEME_SEQUENTIAL:
+                passage_id = str(start_index + offset)
+            elif passage_id_scheme == PASSAGE_ID_SCHEME_EXTERNAL:
+                if explicit_id is None:
+                    raise ValueError(
+                        "Updating an external-ID index requires explicit metadata['id'] for each chunk."
+                    )
+                passage_id = str(explicit_id)
+            else:
+                raise ValueError(
+                    f"Unknown passage_id_scheme in index metadata: {passage_id_scheme!r}"
+                )
+            metadata["id"] = passage_id
+            chunk["id"] = passage_id
 
     def build_index(self, index_path: str):
         if not self.chunks:
@@ -685,20 +736,27 @@ class LeannBuilder:
             f"Building index from precomputed embeddings: {len(ids)} items, {embedding_dim} dimensions"
         )
 
+        string_ids = [str(id_val) for id_val in ids]
+
         # Ensure we have text data for each embedding
         if len(self.chunks) != len(ids):
             # If no text chunks provided, create placeholder text entries
             if not self.chunks:
                 logger.info("No text chunks provided, creating placeholder entries...")
-                for id_val in ids:
+                for id_val in string_ids:
                     self.add_text(
                         f"Document {id_val}",
-                        metadata={"id": str(id_val), "from_embeddings": True},
+                        metadata={"id": id_val, "from_embeddings": True},
                     )
             else:
                 raise ValueError(
                     f"Number of text chunks ({len(self.chunks)}) doesn't match number of embeddings ({len(ids)})"
                 )
+
+        for passage_id, chunk in zip(string_ids, self.chunks):
+            chunk["id"] = passage_id
+            chunk.setdefault("metadata", {})["id"] = passage_id
+            chunk.pop("_generated_id_scheme", None)
 
         # Build file structure
         path = Path(index_path)
@@ -729,7 +787,6 @@ class LeannBuilder:
             pickle.dump(offset_map, f)
 
         # Build the vector index using precomputed embeddings
-        string_ids = [str(id_val) for id_val in ids]
         # Persist ID map (order == embeddings order)
         try:
             idmap_file = (
@@ -754,7 +811,7 @@ class LeannBuilder:
             "dimensions": self.dimensions,
             "backend_kwargs": self.backend_kwargs,
             "embedding_mode": self.embedding_mode,
-            "passage_id_scheme": self.passage_id_scheme,
+            "passage_id_scheme": PASSAGE_ID_SCHEME_EXTERNAL,
             "passage_sources": [
                 {
                     "type": "jsonl",
@@ -858,6 +915,7 @@ class LeannBuilder:
         with open(meta_path, encoding="utf-8") as f:
             meta = json.load(f)
         backend_name = meta.get("backend_name")
+        existing_passage_id_scheme = meta.get("passage_id_scheme", PASSAGE_ID_SCHEME_SEQUENTIAL)
         if backend_name != self.backend_name:
             raise ValueError(
                 f"Index was built with backend '{backend_name}', cannot update with '{self.backend_name}'."
@@ -893,6 +951,7 @@ class LeannBuilder:
 
         if not self.chunks:
             meta["total_passages"] = len(offset_map)
+            meta.setdefault("passage_id_scheme", existing_passage_id_scheme)
             with open(meta_path, "w", encoding="utf-8") as f:
                 json.dump(meta, f, indent=2)
             self.chunks.clear()
@@ -920,19 +979,26 @@ class LeannBuilder:
             text = chunk.get("text", "")
             if not isinstance(text, str) or not text.strip():
                 continue
-            metadata = chunk.setdefault("metadata", {})
-            passage_id = chunk.get("id") or metadata.get("id")
-            if passage_id and passage_id in existing_ids:
-                raise ValueError(f"Passage ID '{passage_id}' already exists in the index.")
             valid_chunks.append(chunk)
 
         if not valid_chunks:
             # Remove-only or file emptied: we may have already removed ids, just update meta
             meta["total_passages"] = len(offset_map)
+            meta.setdefault("passage_id_scheme", existing_passage_id_scheme)
             with open(meta_path, "w", encoding="utf-8") as f:
                 json.dump(meta, f, indent=2)
             self.chunks.clear()
             return
+
+        self._assign_passage_ids_for_existing_scheme(
+            valid_chunks,
+            existing_passage_id_scheme,
+            start_index=len(offset_map),
+        )
+        for chunk in valid_chunks:
+            passage_id = chunk["id"]
+            if passage_id in existing_ids:
+                raise ValueError(f"Passage ID '{passage_id}' already exists in the index.")
 
         texts_to_embed = [chunk["text"] for chunk in valid_chunks]
         embeddings = compute_embeddings(
@@ -959,12 +1025,6 @@ class LeannBuilder:
 
         # IVF: add_vectors then append passages/offset (no ZMQ/server)
         if backend_name == "ivf":
-            for i, chunk in enumerate(valid_chunks):
-                pid = chunk.get("id") or chunk.get("metadata", {}).get("id")
-                if not pid:
-                    pid = str(len(offset_map) + i)
-                chunk.setdefault("metadata", {})["id"] = pid
-                chunk["id"] = pid
             passage_ids = [c["id"] for c in valid_chunks]
             try:
                 from leann_backend_ivf import add_vectors as ivf_add_vectors
@@ -992,6 +1052,7 @@ class LeannBuilder:
                 with open(offset_file, "wb") as f:
                     pickle.dump(offset_map, f)
                 meta["total_passages"] = len(offset_map)
+                meta.setdefault("passage_id_scheme", existing_passage_id_scheme)
                 with open(meta_path, "w", encoding="utf-8") as f:
                     json.dump(meta, f, indent=2)
                 logger.info(
@@ -1046,12 +1107,6 @@ class LeannBuilder:
 
         passage_meta_mode = meta.get("embedding_mode", self.embedding_mode)
         passage_provider_options = meta.get("embedding_options", self.embedding_options)
-
-        base_id = index.ntotal
-        for offset, chunk in enumerate(valid_chunks):
-            new_id = str(base_id + offset)
-            chunk.setdefault("metadata", {})["id"] = new_id
-            chunk["id"] = new_id
 
         # Append passages/offsets before we attempt index.add so the ZMQ server
         # can resolve newly assigned IDs during recompute. Keep rollback hooks
@@ -1135,6 +1190,7 @@ class LeannBuilder:
             raise
 
         meta["total_passages"] = len(offset_map)
+        meta.setdefault("passage_id_scheme", existing_passage_id_scheme)
         with open(meta_path, "w", encoding="utf-8") as f:
             json.dump(meta, f, indent=2)
 

--- a/packages/leann-core/src/leann/cli.py
+++ b/packages/leann-core/src/leann/cli.py
@@ -16,7 +16,15 @@ from llama_index.core import SimpleDirectoryReader
 from llama_index.core.node_parser import SentenceSplitter
 from tqdm import tqdm
 
-from .api import Fts5BM25Index, LeannBuilder, LeannChat, LeannSearcher
+from .api import (
+    DEFAULT_PASSAGE_ID_SCHEME,
+    PASSAGE_ID_SCHEME_CONTENT_HASH,
+    PASSAGE_ID_SCHEME_SEQUENTIAL,
+    Fts5BM25Index,
+    LeannBuilder,
+    LeannChat,
+    LeannSearcher,
+)
 from .embedding_server_manager import EmbeddingServerManager
 from .interactive_utils import create_cli_session
 from .registry import register_project_directory
@@ -75,6 +83,33 @@ def _publish_rebuilt_index(staging_dir: Path, index_dir: Path) -> None:
     else:
         if backup_dir.exists():
             _cleanup_path(backup_dir)
+
+
+@contextlib.contextmanager
+def index_write_lock(index_dir: Path, timeout_seconds: float = 30.0):
+    """Serialize destructive writes to one index directory."""
+    lock_path = index_dir.with_name(f"{index_dir.name}.write.lock")
+    deadline = time.monotonic() + timeout_seconds
+    fd: Optional[int] = None
+    while True:
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.write(fd, str(os.getpid()).encode("utf-8"))
+            break
+        except FileExistsError:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Timed out waiting for index write lock: {lock_path}")
+            time.sleep(0.1)
+
+    try:
+        yield
+    finally:
+        if fd is not None:
+            os.close(fd)
+        try:
+            lock_path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 @contextlib.contextmanager
@@ -389,11 +424,11 @@ Examples:
         build_parser.add_argument(
             "--id-scheme",
             choices=["sequential", "content-hash"],
-            default="sequential",
+            default=DEFAULT_PASSAGE_ID_SCHEME,
             help=(
-                "How passage IDs are assigned. 'sequential' (default) keys by insertion "
-                "order; 'content-hash' uses sha256(text)[:16], stable across file moves "
-                "and reorderings. See #329."
+                "How passage IDs are assigned. 'content-hash' (default) uses sha256(text)[:16], "
+                "stable across file moves and reorderings; 'sequential' keys by insertion order. "
+                "See #329."
             ),
         )
 
@@ -1975,29 +2010,6 @@ Examples:
         for fs in synchronizers:
             fs.commit()
 
-    @staticmethod
-    def _assign_chunk_ids(chunks: list[dict]) -> None:
-        """Assign stable IDs to chunks based on their file path and position."""
-        from collections import defaultdict
-
-        by_path: dict[str, list] = defaultdict(list)
-        for c in chunks:
-            p = c.get("metadata", {}).get("file_path") or c.get("metadata", {}).get("source") or ""
-            by_path[_normalize_path(p)].append(c)
-        for path_key, path_chunks in by_path.items():
-            for idx, c in enumerate(path_chunks):
-                sid = hashlib.sha256(f"{path_key}:{idx}".encode()).hexdigest()[:16]
-                c.setdefault("metadata", {})["id"] = sid
-                c["id"] = sid
-
-    @staticmethod
-    def _assign_unique_chunk_ids(chunks: list[dict]) -> None:
-        """Assign unique IDs for incremental (avoids collision when path lookup misses some old ids)."""
-        for c in chunks:
-            sid = uuid.uuid4().hex[:16]
-            c.setdefault("metadata", {})["id"] = sid
-            c["id"] = sid
-
     def _chunks_for_paths(self, all_texts: list[dict], paths: set[str]) -> list[dict]:
         """Filter chunks belonging to the given file paths."""
         return [
@@ -2021,7 +2033,7 @@ Examples:
             return None
         try:
             with open(meta_path, encoding="utf-8") as f:
-                return json.load(f).get("passage_id_scheme", "sequential")
+                return json.load(f).get("passage_id_scheme", PASSAGE_ID_SCHEME_SEQUENTIAL)
         except Exception:
             return None
 
@@ -2029,7 +2041,7 @@ Examples:
         # For incremental updates, the existing index's scheme wins. Otherwise
         # IDs would mix schemes within one index, which breaks lookups.
         existing_scheme = self._existing_index_id_scheme(self.get_index_path(args.index_name))
-        scheme = existing_scheme or getattr(args, "id_scheme", "sequential")
+        scheme = existing_scheme or getattr(args, "id_scheme", DEFAULT_PASSAGE_ID_SCHEME)
         if existing_scheme and getattr(args, "id_scheme", existing_scheme) != existing_scheme:
             print(
                 f"Note: --id-scheme={args.id_scheme} ignored — index '{args.index_name}' "
@@ -2059,7 +2071,6 @@ Examples:
         new_chunks = self._chunks_for_paths(all_texts, new_paths)
         if not new_chunks:
             return False
-        self._assign_chunk_ids(new_chunks)
         builder = self._make_incremental_builder(args)
         for chunk in new_chunks:
             builder.add_text(chunk["text"], metadata=chunk["metadata"])
@@ -2153,9 +2164,6 @@ Examples:
         for p in changed_paths:
             path_set.update(self._path_lookup_keys(p, sync_roots))
         new_chunks = self._chunks_for_paths(all_texts, path_set)
-        # Use unique IDs: passages can have mixed path formats so we may miss some ids_to_remove
-        self._assign_unique_chunk_ids(new_chunks)
-
         if not ids_to_remove and not new_chunks:
             return False
 
@@ -2559,7 +2567,7 @@ Examples:
             is_compact=args.compact,
             is_recompute=args.recompute,
             num_threads=args.num_threads,
-            passage_id_scheme=getattr(args, "id_scheme", "sequential"),
+            passage_id_scheme=getattr(args, "id_scheme", DEFAULT_PASSAGE_ID_SCHEME),
         )
 
         for chunk in all_texts:
@@ -2587,7 +2595,8 @@ Examples:
                 build_config,
             )
             if publish_from_staging:
-                _publish_rebuilt_index(target_index_dir, index_dir)
+                with index_write_lock(index_dir):
+                    _publish_rebuilt_index(target_index_dir, index_dir)
         except Exception:
             if publish_from_staging and target_index_dir.exists():
                 import shutil
@@ -2845,8 +2854,8 @@ Examples:
             return
         with open(meta_path, encoding="utf-8") as f:
             meta = json.load(f)
-        current_scheme = meta.get("passage_id_scheme", "sequential")
-        if current_scheme == "content-hash":
+        current_scheme = meta.get("passage_id_scheme", PASSAGE_ID_SCHEME_SEQUENTIAL)
+        if current_scheme == PASSAGE_ID_SCHEME_CONTENT_HASH:
             print(f"Index '{index_name}' already uses content-hash IDs. Nothing to do.")
             return
 
@@ -2867,14 +2876,12 @@ Examples:
 
         # Stream the passages to plan the rewrite and surface collision count
         # before committing to anything irreversible.
-        old_ids: list[str] = []
         new_ids: list[str] = []
         with open(passages_file, encoding="utf-8") as f:
             for line in f:
                 if not line.strip():
                     continue
                 data = json.loads(line)
-                old_ids.append(data["id"])
                 new_ids.append(hashlib.sha256(data["text"].encode("utf-8")).hexdigest()[:16])
 
         unique_new = len(set(new_ids))
@@ -2895,65 +2902,83 @@ Examples:
                 print("Aborted.")
                 return
 
-        # Stage writes into siblings, then atomically rename.
-        new_passages = passages_file.with_suffix(passages_file.suffix + ".migrate")
-        new_offsets: dict[str, int] = {}
-        rewritten_passages: list[dict[str, Any]] = []
-        with (
-            open(passages_file, encoding="utf-8") as src,
-            open(new_passages, "w", encoding="utf-8") as dst,
-        ):
-            idx = 0
-            for line in src:
-                if not line.strip():
-                    continue
-                data = json.loads(line)
-                data["id"] = new_ids[idx]
-                offset = dst.tell()
-                json.dump(data, dst, ensure_ascii=False)
-                dst.write("\n")
-                new_offsets[new_ids[idx]] = offset
-                rewritten_passages.append(data)
-                idx += 1
+        with index_write_lock(index_dir):
+            with open(meta_path, encoding="utf-8") as f:
+                meta = json.load(f)
+            current_scheme = meta.get("passage_id_scheme", PASSAGE_ID_SCHEME_SEQUENTIAL)
+            if current_scheme == PASSAGE_ID_SCHEME_CONTENT_HASH:
+                print(f"Index '{index_name}' already uses content-hash IDs. Nothing to do.")
+                return
 
-        new_idx = offset_file.with_suffix(offset_file.suffix + ".migrate")
-        with open(new_idx, "wb") as f:
-            pickle.dump(new_offsets, f)
+            new_ids = []
+            with open(passages_file, encoding="utf-8") as f:
+                for line in f:
+                    if not line.strip():
+                        continue
+                    data = json.loads(line)
+                    new_ids.append(hashlib.sha256(data["text"].encode("utf-8")).hexdigest()[:16])
+            unique_new = len(set(new_ids))
+            collisions = len(new_ids) - unique_new
 
-        new_idmap: Optional[Path] = None
-        if idmap_file.exists():
-            new_idmap = idmap_file.with_suffix(idmap_file.suffix + ".migrate")
-            with open(new_idmap, "w", encoding="utf-8") as f:
-                for nid in new_ids:
-                    f.write(nid + "\n")
+            # Stage writes into siblings, then atomically rename.
+            new_passages = passages_file.with_suffix(passages_file.suffix + ".migrate")
+            new_offsets: dict[str, int] = {}
+            rewritten_passages: list[dict[str, Any]] = []
+            with (
+                open(passages_file, encoding="utf-8") as src,
+                open(new_passages, "w", encoding="utf-8") as dst,
+            ):
+                idx = 0
+                for line in src:
+                    if not line.strip():
+                        continue
+                    data = json.loads(line)
+                    data["id"] = new_ids[idx]
+                    offset = dst.tell()
+                    json.dump(data, dst, ensure_ascii=False)
+                    dst.write("\n")
+                    new_offsets[new_ids[idx]] = offset
+                    rewritten_passages.append(data)
+                    idx += 1
 
-        bm25_db_name = meta.get("bm25_db")
-        should_rebuild_bm25 = meta.get("bm25_backend") == "fts5"
-        if should_rebuild_bm25 and not bm25_db_name:
-            bm25_db_name = f"{index_base}.bm25.sqlite"
-        new_bm25: Optional[Path] = None
-        bm25_file: Optional[Path] = None
-        if should_rebuild_bm25 and bm25_db_name:
-            bm25_file = index_dir / bm25_db_name
-            new_bm25 = bm25_file.with_suffix(bm25_file.suffix + ".migrate")
-            bm25_index = Fts5BM25Index(str(new_bm25))
-            bm25_index.fit(rewritten_passages)
-            bm25_index.close()
+            new_idx = offset_file.with_suffix(offset_file.suffix + ".migrate")
+            with open(new_idx, "wb") as f:
+                pickle.dump(new_offsets, f)
 
-        shutil.move(str(new_passages), str(passages_file))
-        shutil.move(str(new_idx), str(offset_file))
-        if new_idmap is not None:
-            shutil.move(str(new_idmap), str(idmap_file))
-        if new_bm25 is not None and bm25_file is not None:
-            shutil.move(str(new_bm25), str(bm25_file))
+            new_idmap: Optional[Path] = None
+            if idmap_file.exists():
+                new_idmap = idmap_file.with_suffix(idmap_file.suffix + ".migrate")
+                with open(new_idmap, "w", encoding="utf-8") as f:
+                    for nid in new_ids:
+                        f.write(nid + "\n")
 
-        meta["passage_id_scheme"] = "content-hash"
-        meta["version"] = "1.1"
-        if should_rebuild_bm25 and bm25_db_name:
-            meta["bm25_backend"] = "fts5"
-            meta["bm25_db"] = bm25_db_name
-        with open(meta_path, "w", encoding="utf-8") as f:
-            json.dump(meta, f, indent=2)
+            bm25_db_name = meta.get("bm25_db")
+            should_rebuild_bm25 = meta.get("bm25_backend") == "fts5"
+            if should_rebuild_bm25 and not bm25_db_name:
+                bm25_db_name = f"{index_base}.bm25.sqlite"
+            new_bm25: Optional[Path] = None
+            bm25_file: Optional[Path] = None
+            if should_rebuild_bm25 and bm25_db_name:
+                bm25_file = index_dir / bm25_db_name
+                new_bm25 = bm25_file.with_suffix(bm25_file.suffix + ".migrate")
+                bm25_index = Fts5BM25Index(str(new_bm25))
+                bm25_index.fit(rewritten_passages)
+                bm25_index.close()
+
+            shutil.move(str(new_passages), str(passages_file))
+            shutil.move(str(new_idx), str(offset_file))
+            if new_idmap is not None:
+                shutil.move(str(new_idmap), str(idmap_file))
+            if new_bm25 is not None and bm25_file is not None:
+                shutil.move(str(new_bm25), str(bm25_file))
+
+            meta["passage_id_scheme"] = PASSAGE_ID_SCHEME_CONTENT_HASH
+            meta["version"] = "1.1"
+            if should_rebuild_bm25 and bm25_db_name:
+                meta["bm25_backend"] = "fts5"
+                meta["bm25_db"] = bm25_db_name
+            with open(meta_path, "w", encoding="utf-8") as f:
+                json.dump(meta, f, indent=2)
 
         print(
             f"✓ Migrated '{index_name}' to content-hash IDs. {collisions} collisions were deduped."

--- a/tests/test_build_from_arrays.py
+++ b/tests/test_build_from_arrays.py
@@ -3,6 +3,7 @@ Tests for LeannBuilder.build_index_from_arrays and its integration with
 build_index_from_embeddings (pickle-based path).
 """
 
+import json
 import os
 import pickle
 import tempfile
@@ -10,6 +11,61 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from leann.api import PASSAGE_ID_SCHEME_EXTERNAL, LeannBuilder
+
+
+def test_build_from_arrays_marks_external_ids_and_aligns_passages():
+    """Precomputed embeddings use caller-provided IDs, not generated content hashes."""
+
+    built_ids = []
+
+    class FakeBackendFactory:
+        def builder(self, **_kwargs):
+            class FakeBackendBuilder:
+                def build(self, _embeddings, ids, _index_path, **_backend_kwargs):
+                    built_ids.extend(ids)
+
+            return FakeBackendBuilder()
+
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+        index_path = str(Path(temp_dir) / "external_ids.hnsw")
+        builder = LeannBuilder(
+            backend_name="hnsw",
+            embedding_model="facebook/contriever",
+            embedding_mode="sentence-transformers",
+            dimensions=2,
+        )
+        builder.backend_factory = FakeBackendFactory()
+        builder.add_text("alpha text")
+        builder.add_text("beta text")
+
+        embeddings = np.array([[0.1, 0.2], [0.3, 0.4]], dtype=np.float32)
+        ids = ["doc-a", "doc-b"]
+        builder.build_index_from_arrays(index_path, ids, embeddings)
+
+        passages_file = Path(index_path).parent / f"{Path(index_path).name}.passages.jsonl"
+        passages = [
+            json.loads(line)
+            for line in passages_file.read_text(encoding="utf-8").splitlines()
+            if line
+        ]
+        assert [p["id"] for p in passages] == ids
+        assert [p["metadata"]["id"] for p in passages] == ids
+        assert built_ids == ids
+
+        idmap_file = Path(index_path).parent / "external_ids.hnsw.ids.txt"
+        assert idmap_file.read_text(encoding="utf-8").splitlines() == ids
+
+        with open(Path(index_path).parent / f"{Path(index_path).name}.passages.idx", "rb") as f:
+            offset_map = pickle.load(f)
+        assert set(offset_map) == set(ids)
+
+        meta = json.loads(
+            (Path(index_path).parent / f"{Path(index_path).name}.meta.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert meta["passage_id_scheme"] == PASSAGE_ID_SCHEME_EXTERNAL
 
 
 @pytest.mark.skipif(

--- a/tests/test_passage_id_scheme.py
+++ b/tests/test_passage_id_scheme.py
@@ -1,14 +1,30 @@
 import hashlib
 import json
 import pickle
+from contextlib import contextmanager
 from types import SimpleNamespace
 
-from leann.api import Fts5BM25Index, LeannBuilder
+from leann.api import (
+    DEFAULT_PASSAGE_ID_SCHEME,
+    PASSAGE_ID_SCHEME_CONTENT_HASH,
+    PASSAGE_ID_SCHEME_SEQUENTIAL,
+    Fts5BM25Index,
+    LeannBuilder,
+)
 from leann.cli import LeannCLI
 
 
 def _content_id(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def test_builder_defaults_to_content_hash_passage_ids():
+    builder = LeannBuilder(backend_name="hnsw")
+
+    builder.add_text("same text", metadata={"source": "a.txt"})
+
+    assert DEFAULT_PASSAGE_ID_SCHEME == PASSAGE_ID_SCHEME_CONTENT_HASH
+    assert builder.chunks[0]["id"] == _content_id("same text")
 
 
 def test_builder_content_hash_passage_ids_are_content_stable():
@@ -22,6 +38,35 @@ def test_builder_content_hash_passage_ids_are_content_stable():
     assert builder.chunks[0]["id"] == same_id
     assert builder.chunks[1]["id"] == same_id
     assert builder.chunks[2]["id"] == _content_id("different text")
+
+
+def test_update_passage_ids_follow_existing_sequential_index_scheme():
+    builder = LeannBuilder(backend_name="hnsw")
+    builder.add_text("new text", metadata={"source": "new.txt"})
+    assert builder.chunks[0]["id"] == _content_id("new text")
+
+    builder._assign_passage_ids_for_existing_scheme(
+        builder.chunks,
+        PASSAGE_ID_SCHEME_SEQUENTIAL,
+        start_index=2,
+    )
+
+    assert builder.chunks[0]["id"] == "2"
+    assert builder.chunks[0]["metadata"]["id"] == "2"
+
+
+def test_update_passage_ids_preserve_explicit_api_ids():
+    builder = LeannBuilder(backend_name="hnsw")
+    builder.add_text("new text", metadata={"id": "caller-id"})
+
+    builder._assign_passage_ids_for_existing_scheme(
+        builder.chunks,
+        PASSAGE_ID_SCHEME_CONTENT_HASH,
+        start_index=2,
+    )
+
+    assert builder.chunks[0]["id"] == "caller-id"
+    assert builder.chunks[0]["metadata"]["id"] == "caller-id"
 
 
 def test_existing_index_id_scheme_treats_legacy_meta_as_sequential(tmp_path):
@@ -90,8 +135,19 @@ def test_migrate_ids_rewrites_passages_offsets_idmap_meta_and_bm25(tmp_path, mon
         encoding="utf-8",
     )
 
+    lock_paths = []
+
+    @contextmanager
+    def fake_index_write_lock(path):
+        lock_paths.append(path)
+        yield
+
+    monkeypatch.setattr("leann.cli.index_write_lock", fake_index_write_lock)
+
     cli = LeannCLI()
     cli.migrate_ids(SimpleNamespace(index_name="sample", dry_run=False, yes=True))
+
+    assert lock_paths == [index_dir]
 
     expected_ids = [_content_id("alpha beta"), _content_id("gamma delta")]
     with open(passages_file, encoding="utf-8") as f:
@@ -115,3 +171,58 @@ def test_migrate_ids_rewrites_passages_offsets_idmap_meta_and_bm25(tmp_path, mon
     finally:
         migrated_bm25.close()
     assert [result.id for result in bm25_results] == [expected_ids[0]]
+
+
+def test_migrate_ids_recomputes_passage_plan_under_write_lock(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    index_dir = tmp_path / ".leann" / "indexes" / "sample"
+    index_dir.mkdir(parents=True)
+
+    passages_file = index_dir / "documents.leann.passages.jsonl"
+    passages_file.write_text(
+        json.dumps({"id": "0", "text": "pre lock text", "metadata": {}}) + "\n",
+        encoding="utf-8",
+    )
+
+    offset_file = index_dir / "documents.leann.passages.idx"
+    with open(offset_file, "wb") as f:
+        pickle.dump({"0": 0}, f)
+
+    idmap_file = index_dir / "documents.ids.txt"
+    idmap_file.write_text("0\n", encoding="utf-8")
+
+    meta_path = index_dir / "documents.leann.meta.json"
+    meta_path.write_text(
+        json.dumps(
+            {
+                "version": "1.0",
+                "backend_name": "hnsw",
+                "embedding_model": "dummy",
+                "dimensions": 3,
+                "backend_kwargs": {},
+                "embedding_mode": "sentence-transformers",
+                "passage_id_scheme": "sequential",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    @contextmanager
+    def fake_index_write_lock(path):
+        assert path == index_dir
+        passages_file.write_text(
+            json.dumps({"id": "0", "text": "post lock text", "metadata": {}}) + "\n",
+            encoding="utf-8",
+        )
+        yield
+
+    monkeypatch.setattr("leann.cli.index_write_lock", fake_index_write_lock)
+
+    cli = LeannCLI()
+    cli.migrate_ids(SimpleNamespace(index_name="sample", dry_run=False, yes=True))
+
+    expected_id = _content_id("post lock text")
+    with open(passages_file, encoding="utf-8") as f:
+        migrated_passages = [json.loads(line) for line in f if line.strip()]
+    assert [p["id"] for p in migrated_passages] == [expected_id]
+    assert idmap_file.read_text(encoding="utf-8").splitlines() == [expected_id]

--- a/tests/test_rebuild_cli.py
+++ b/tests/test_rebuild_cli.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import pickle
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -346,3 +347,96 @@ def test_full_rebuild_failure_preserves_existing_index(tmp_path, monkeypatch):
         path: path.read_bytes() for path in (meta_path, passages_file, offset_file)
     } == original_artifacts
     assert not list(index_dir.parent.glob(".sample.rebuild-*"))
+
+
+def test_full_rebuild_publish_uses_index_write_lock(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    docs_root = tmp_path / "docs"
+    docs_root.mkdir()
+    docs_file = docs_root / "only.md"
+    docs_file.write_text("hello", encoding="utf-8")
+
+    cli = LeannCLI()
+    index_dir = tmp_path / ".leann" / "indexes" / "sample"
+    index_dir.mkdir(parents=True)
+    (index_dir / "documents.leann.meta.json").write_text(
+        json.dumps(
+            {
+                "backend_name": "hnsw",
+                "embedding_model": "facebook/contriever",
+                "embedding_mode": "sentence-transformers",
+                "backend_kwargs": {"is_compact": False, "is_recompute": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (index_dir / "documents.leann.passages.jsonl").write_text(
+        json.dumps({"id": "old", "text": "old text", "metadata": {}}) + "\n",
+        encoding="utf-8",
+    )
+    with open(index_dir / "documents.leann.passages.idx", "wb") as f:
+        pickle.dump({"old": 0}, f)
+
+    args = cli.create_parser().parse_args(
+        [
+            "build",
+            "sample",
+            "--docs",
+            str(docs_file),
+            "--backend-name",
+            "hnsw",
+            "--force",
+        ]
+    )
+    lock_paths = []
+
+    @contextmanager
+    def fake_index_write_lock(path):
+        lock_paths.append(path)
+        yield
+
+    class FakeSynchronizer:
+        def create_snapshot(self):
+            pass
+
+    class SuccessfulBuilder:
+        def __init__(self, **_kwargs):
+            pass
+
+        def add_text(self, _text, metadata=None):
+            pass
+
+        def build_index(self, index_path):
+            target_dir = Path(index_path).parent
+            target_dir.mkdir(parents=True, exist_ok=True)
+            (target_dir / "documents.leann.meta.json").write_text(
+                json.dumps(
+                    {
+                        "backend_name": "hnsw",
+                        "embedding_model": "facebook/contriever",
+                        "embedding_mode": "sentence-transformers",
+                        "backend_kwargs": {"is_compact": False, "is_recompute": True},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (target_dir / "documents.leann.passages.jsonl").write_text(
+                json.dumps({"id": "new", "text": "new text", "metadata": {}}) + "\n",
+                encoding="utf-8",
+            )
+            with open(target_dir / "documents.leann.passages.idx", "wb") as f:
+                pickle.dump({"new": 0}, f)
+
+    monkeypatch.setattr("leann.cli.index_write_lock", fake_index_write_lock)
+    monkeypatch.setattr(cli, "_build_synchronizers", lambda *_args, **_kwargs: [FakeSynchronizer()])
+    monkeypatch.setattr(
+        cli,
+        "load_documents",
+        lambda *_args, **_kwargs: [{"text": "rebuilt", "metadata": {"file_path": str(docs_file)}}],
+    )
+    monkeypatch.setattr(cli, "register_project_dir", lambda: None)
+    monkeypatch.setattr("leann.cli.LeannBuilder", SuccessfulBuilder)
+
+    asyncio.run(cli.build_index(args))
+
+    assert lock_paths == [index_dir]


### PR DESCRIPTION

This follows up on the opt-in content-hash ID (#347) work by making content-hash the default generated passage ID scheme for new indexes. The main goal is to get stable passage IDs by default without mixing ID schemes in existing indexes or mislabeling caller-provided IDs.

Design choices:

- Defaults generated passage IDs to `content-hash` for new `LeannBuilder` and CLI builds.
- Keeps incremental updates aligned with the existing index metadata, so legacy sequential indexes continue appending sequential IDs.
- Marks precomputed array-built indexes as `external` and keeps passage JSONL, offset maps, backend labels, id maps, and metadata aligned to caller-provided IDs.
- Adds a shared index write lock around full-rebuild publish and ID migration rewrites, including a regression test for stale migration planning under concurrent writes.
