### PR TITLE
fix(mcp): respond -32601 to unknown request methods instead of silence

### DIFF
--- a/packages/leann-core/src/leann/mcp.py
+++ b/packages/leann-core/src/leann/mcp.py
@@ -362,6 +362,17 @@ def handle_request(request):
         except Exception as e:
             return _make_error(request_id, str(e))
 
+    # Unknown method: a request (with an id) must get a -32601 error response
+    # so strict clients can fall back — e.g. Google Antigravity CLI probes
+    # with a server/discover request before initialize and hangs forever
+    # ("initializing...") if the server stays silent. Notifications (no id)
+    # must get no reply at all (JSON-RPC 2.0).
+    if request_id is not None:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": "Method not found"},
+        }
     return None
 
 


### PR DESCRIPTION
## Problem

`handle_request()` returns `None` for any unrecognized method, and `main()` only prints when a response exists — so unknown JSON-RPC **requests** get no reply at all.

Newer MCP clients probe servers before initializing. Google Antigravity CLI (MCP protocol `2026-07-28`) opens with a `server/discover` request; when `leann_mcp` stays silent, the client waits indefinitely and the server shows **"initializing..." forever** in agy's MCP panel. Claude Code and Gemini CLI never send the probe, which is why the bug is invisible there.

## Fix

Per JSON-RPC 2.0, at the end of `handle_request()`:
- unknown **request** (has an `id`) → `-32601 Method not found`, so the client can fall back
- unknown **notification** (no `id`) → no reply (current behavior, still correct)

Eleven lines, no behavior change for any known method.

## Verification

Replayed Antigravity CLI 1.1.3's captured opening bytes (`server/discover` request + `notifications/roots/list_changed` notification, then `initialize` + `tools/list`) against this branch's `mcp.py`:

```
id 1 ERROR: Method not found   <- server/discover, client falls back
id 2 ok                        <- initialize
id 3 ok: 4 tools               <- tools/list
```

(notification correctly got no reply)

Live-tested the same fallback against Antigravity CLI 1.1.3 on macOS: previously stuck at "initializing..." indefinitely; with the fallback the server settles in ~1s with all tools listed. Claude Code behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)