### PR TITLE
fix(ci): add Python 3.14 build matrix rows for macOS/Linux

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -83,6 +83,8 @@ jobs:
             python: '3.12'
           - os: ubuntu-22.04
             python: '3.13'
+          - os: ubuntu-22.04
+            python: '3.14'
           # ARM64 Linux builds
           - os: ubuntu-22.04-arm
             python: '3.10'
@@ -92,6 +94,8 @@ jobs:
             python: '3.12'
           - os: ubuntu-22.04-arm
             python: '3.13'
+          - os: ubuntu-22.04-arm
+            python: '3.14'
           - os: macos-14
             python: '3.10'
           - os: macos-14
@@ -100,6 +104,8 @@ jobs:
             python: '3.12'
           - os: macos-14
             python: '3.13'
+          - os: macos-14
+            python: '3.14'
           - os: macos-15
             python: '3.10'
           - os: macos-15
@@ -108,9 +114,12 @@ jobs:
             python: '3.12'
           - os: macos-15
             python: '3.13'
+          - os: macos-15
+            python: '3.14'
           # Intel Mac builds (x86_64) - replaces deprecated macos-13
-          # Note: Python 3.13 excluded - PyTorch has no wheels for macOS x86_64 + Python 3.13
-          # (PyTorch <=2.4.1 lacks cp313, PyTorch >=2.5.0 dropped Intel Mac support)
+          # Note: Python 3.13+ excluded - PyTorch has no wheels for macOS x86_64 + Python >=3.13
+          # (PyTorch <=2.4.1 lacks cp313, PyTorch >=2.5.0 dropped Intel Mac support;
+          # no macosx x86_64 cp314 wheel either as of torch 2.13.0)
           - os: macos-15-intel
             python: '3.10'
           - os: macos-15-intel
@@ -126,6 +135,8 @@ jobs:
             python: '3.12'
           - os: macos-26
             python: '3.13'
+          - os: macos-26
+            python: '3.14'
           # Windows validation (native HNSW + DiskANN build/install path)
           - os: windows-2022
             python: '3.11'

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,3 +46,23 @@ fixes). Newest entries at the bottom.
 - Bound App-format metadata discovery to a configurable directory depth; `leann list` defaults to depth 5 and accepts `--max-depth` for deeper projects.
 - Prune common dependency, virtual-environment, cache, and system directories during discovery.
 - Preserve discovery of registered CLI-format and App-format projects without recursively scanning an entire home directory.
+
+## 2026-07-29: CI build matrix — Python 3.14 wheels for macOS/Linux (#385)
+
+- `leann-backend-hnsw` and `leann-backend-diskann` 0.3.7 only shipped a `cp314`
+  wheel for `win_amd64` (the CI build matrix had a `windows-2022` / Python 3.14
+  row but no equivalent for macOS or Linux), and neither package set
+  `requires-python`. Resolvers on Python 3.14 (macOS/Linux) selected the
+  release anyway and then failed with a confusing "only has wheels for
+  `win_amd64`" error instead of a clear incompatibility message.
+- Extended `.github/workflows/build-reusable.yml`'s build matrix with Python
+  3.14 rows for `ubuntu-22.04`, `ubuntu-22.04-arm`, `macos-14`, `macos-15`, and
+  `macos-26`, matching the Windows coverage. `macos-15-intel` (x86_64) is
+  intentionally excluded, consistent with its existing Python 3.13 exclusion —
+  PyTorch (a `leann-core` dependency) publishes no `macosx x86_64` wheel for
+  either version.
+- A `requires-python` upper bound was considered instead but rejected: the
+  bound applies uniformly across platforms, so it would have also blocked the
+  already-working Windows `cp314` installs. Completing the wheel matrix is the
+  correct fix; the next 0.3.8 patch release will carry full `cp314` coverage
+  once CI confirms the new platforms build cleanly.


### PR DESCRIPTION
leann-backend-hnsw and leann-backend-diskann 0.3.7 only shipped a cp314 wheel for win_amd64 — the build matrix had a windows-2022 / Python 3.14 row but no macOS or Linux equivalent, and neither package sets requires-python. Resolvers on Python 3.14 (macOS/Linux) select the release anyway and fail with a confusing "only has wheels for win_amd64" error instead of a clear incompatibility message.

A requires-python upper bound was considered but rejected: it isn't platform-conditional, so it would also block the already-working Windows cp314 wheels. Complete the build matrix instead: add Python 3.14 rows for ubuntu-22.04, ubuntu-22.04-arm, macos-14, macos-15, and macos-26, matching Windows coverage. macos-15-intel is intentionally excluded, consistent with its existing 3.13 exclusion — torch publishes no macosx x86_64 wheel for either version.

Fixes #385.

## What does this PR do?

<!-- Brief description of your changes -->

## Related Issues

Fixes #

## Checklist

- [ ] Tests pass (`uv run pytest`)
- [ ] Code formatted (`ruff format` and `ruff check`)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
