### PR TITLE
fix: Windows MCP encoding crash and build abort on empty/corrupted PDFs

### DIFF
--- a/packages/leann-core/src/leann/cli.py
+++ b/packages/leann-core/src/leann/cli.py
@@ -175,6 +175,11 @@ def suppress_cpp_output(suppress: bool = True):
 def extract_pdf_text_with_pymupdf(file_path: str) -> str | None:
     """Extract text from PDF using PyMuPDF for better quality."""
     try:
+        if os.path.getsize(file_path) == 0:
+            # Empty file: nothing to extract, skip instead of letting
+            # fitz.EmptyFileError abort the whole build.
+            return ""
+
         import fitz  # PyMuPDF
 
         doc = fitz.open(file_path)
@@ -186,11 +191,18 @@ def extract_pdf_text_with_pymupdf(file_path: str) -> str | None:
     except ImportError:
         # Fallback to default reader
         return None
+    except Exception:
+        # Skip corrupted PDFs instead of aborting the whole build
+        return ""
 
 
 def extract_pdf_text_with_pdfplumber(file_path: str) -> str | None:
     """Extract text from PDF using pdfplumber for better quality."""
     try:
+        if os.path.getsize(file_path) == 0:
+            # Empty file: nothing to extract, skip instead of aborting the build.
+            return ""
+
         import pdfplumber
 
         text = ""
@@ -201,6 +213,9 @@ def extract_pdf_text_with_pdfplumber(file_path: str) -> str | None:
     except ImportError:
         # Fallback to default reader
         return None
+    except Exception:
+        # Skip corrupted PDFs instead of aborting the whole build
+        return ""
 
 
 class LeannCLI:

--- a/packages/leann-core/src/leann/mcp.py
+++ b/packages/leann-core/src/leann/mcp.py
@@ -21,9 +21,14 @@ def _leann_cmd() -> list[str]:
 def _run_leann(*args, timeout=120):
     """Run a leann CLI command and return (returncode, stdout, stderr)."""
     result = subprocess.run(
-        ["leann", *args],
+        [*_leann_cmd(), *args],
         capture_output=True,
         text=True,
+        # The leann CLI prints UTF-8 (emoji, CJK, ...). Decode explicitly:
+        # text=True alone falls back to the locale encoding (e.g. GBK on
+        # Chinese Windows) and crashes the subprocess reader thread.
+        encoding="utf-8",
+        errors="replace",
         timeout=timeout,
     )
     return result.returncode, result.stdout, result.stderr


### PR DESCRIPTION
## What does this PR do?

Two Windows fixes, both reproduced on Windows 11 + Python 3.11 (leann-core 0.3.7):

- **fix(mcp): decode leann CLI output explicitly as UTF-8** (`errors="replace"`).
  Plain `text=True` decodes subprocess output with the locale encoding (GBK on
  Chinese Windows). Since the `leann` CLI prints emoji/CJK (UTF-8), the subprocess
  reader thread crashed with `UnicodeDecodeError` and every MCP tool call returned
  `{"text": null}`. Fixed by passing `encoding="utf-8"` explicitly.
- **fix(mcp): actually use the existing `_leann_cmd()` helper.**
  `_leann_cmd()` (`sys.executable -m leann`) was defined but never called;
  `_run_leann` still did a bare `["leann", ...]` lookup, which fails with
  `WinError 2` when the `leann` console-script is not on PATH — exactly the
  situation the helper's docstring describes (MCP client wrappers on Windows).
- **fix(cli): skip empty or corrupted PDFs during `leann build`.**
  A 0-byte or damaged PDF raised `pymupdf.EmptyFileError` (or similar) from
  `fitz.open()` / `pdfplumber.open()` and aborted the entire build. Both
  `extract_pdf_text_with_pymupdf` and `extract_pdf_text_with_pdfplumber` now
  return `""` for empty/unopenable files so the rest of the document set still
  gets indexed.

Note: the related Windows crash in `search_documents` JSON mode (`ctypes.CDLL(None)`)
was already fixed by #312.

## Related Issues

Relates to #14

## Checklist

- [x] Tests pass (`uv run pytest`) — ran related suites: `test_mcp_standalone.py`,
  `test_mcp_integration.py`, `test_cli_verbosity.py`, `test_rebuild_cli.py`
  (26 passed); empty-PDF extraction verified manually
- [x] Code formatted (`ruff format` and `ruff check`)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`) — not run (pre-commit not installed locally)
